### PR TITLE
release: Raycast-inspired UI/UX redesign

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Upstash Redis (visitor counter)
+# Get these from https://console.upstash.com → Redis → your database → REST API
+UPSTASH_REDIS_REST_URL=https://your-endpoint.upstash.io
+UPSTASH_REDIS_REST_TOKEN=your-token-here

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   build:

--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -1,0 +1,22 @@
+name: PR Target Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Only allow PRs from dev to main
+        if: github.head_ref != 'dev'
+        run: |
+          echo "::error::PRs targeting 'main' are only allowed from the 'dev' branch."
+          echo "Please target 'dev' instead, or merge your branch into 'dev' first."
+          echo ""
+          echo "  Source: ${{ github.head_ref }}"
+          echo "  Target: ${{ github.base_ref }}"
+          exit 1
+      - name: PR source branch is valid
+        if: github.head_ref == 'dev'
+        run: echo "PR from 'dev' to 'main' — allowed."

--- a/src/components/BackToTop.astro
+++ b/src/components/BackToTop.astro
@@ -1,0 +1,82 @@
+<!-- Back to top button: shows after scrolling 500px -->
+<button id="back-to-top" class="back-to-top" aria-label="Back to top" title="Back to top">
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+    <polyline points="18 15 12 9 6 15"></polyline>
+  </svg>
+</button>
+
+<script is:inline>
+(function() {
+  var btn = document.getElementById('back-to-top');
+  if (!btn) return;
+
+  var visible = false;
+  function toggle() {
+    var show = window.scrollY > 500;
+    if (show !== visible) {
+      visible = show;
+      btn.classList.toggle('back-to-top-visible', show);
+    }
+  }
+
+  window.addEventListener('scroll', toggle, { passive: true });
+  toggle();
+
+  btn.addEventListener('click', function() {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  });
+})();
+</script>
+
+<style>
+  .back-to-top {
+    position: fixed;
+    bottom: 90px;
+    right: var(--space-xl, 24px);
+    z-index: 8000;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--bg-elevated, #fff);
+    border: 1px solid var(--border, #e5e5e5);
+    border-radius: var(--radius-full, 999px);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    color: var(--text-muted, #666);
+    cursor: pointer;
+    opacity: 0;
+    transform: translateY(10px);
+    pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease, color 0.15s ease, border-color 0.15s ease;
+  }
+
+  .back-to-top-visible {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  .back-to-top:hover {
+    color: var(--text, #333);
+    border-color: var(--border-strong, #ccc);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  }
+
+  @media (max-width: 480px) {
+    .back-to-top {
+      right: var(--space-md, 12px);
+      bottom: 80px;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .back-to-top {
+      transition: opacity 0.1s ease;
+      transform: none;
+    }
+    .back-to-top-visible {
+      transform: none;
+    }
+  }
+</style>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -4,45 +4,78 @@ const year = new Date().getFullYear();
 
 <footer class="footer">
   <div class="container footer-inner">
-    <div class="footer-brand">
+    <div class="footer-col footer-brand-col">
       <span class="footer-logo">
         <img src="/logo.svg" alt="OGCOPS" class="footer-logo-img" width="100" height="25" />
       </span>
       <span class="footer-tagline">Free OG Image Generator</span>
+      <span class="footer-byline">A tool by <a href="https://www.codercops.com" target="_blank" rel="noopener">CODERCOPS</a></span>
     </div>
-    <div class="footer-links">
-      <a href="/create">Create</a>
-      <a href="/preview">Preview</a>
-      <a href="/templates">Templates</a>
-      <a href="/api-docs">API</a>
-      <a href="https://github.com/codercops/ogcops" target="_blank" rel="noopener">GitHub</a>
+
+    <div class="footer-col footer-links-col">
+      <span class="footer-col-title">Product</span>
+      <nav class="footer-nav">
+        <a href="/create">Create</a>
+        <a href="/preview">Preview</a>
+        <a href="/templates">Templates</a>
+        <a href="/api-docs">API Docs</a>
+        <a href="https://github.com/codercops/ogcops" target="_blank" rel="noopener">GitHub</a>
+      </nav>
     </div>
-    <div class="footer-meta">
-      <span class="footer-mit">MIT License</span>
-      <span class="footer-copy">&copy; {year} <a href="https://codercops.com" target="_blank" rel="noopener">CODERCOPS</a></span>
+
+    <div class="footer-col footer-stats-col">
+      <span class="footer-col-title">Stats</span>
+      <div class="footer-stats" aria-label="Visitor statistics">
+        <span class="stat-item">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+          Today: <span id="visitors-today" class="stat-num">-</span>
+        </span>
+        <span class="stat-item">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+          Total: <span id="visitors-total" class="stat-num">-</span>
+        </span>
+      </div>
+      <div class="footer-meta">
+        <span class="footer-mit">MIT License</span>
+        <span class="footer-copy">&copy; {year} <a href="https://codercops.com" target="_blank" rel="noopener">CODERCOPS</a></span>
+      </div>
     </div>
   </div>
 </footer>
 
 <style>
   .footer {
-    border-top: 1px solid var(--border);
-    padding: var(--space-2xl) 0;
+    position: relative;
+    padding: var(--space-3xl) 0 var(--space-2xl);
     margin-top: auto;
+    background: linear-gradient(180deg, transparent 0%, rgba(224, 122, 95, 0.02) 100%);
+  }
+
+  .footer::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent 0%, var(--border) 20%, var(--accent-primary-muted) 50%, var(--border) 80%, transparent 100%);
   }
 
   .footer-inner {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-wrap: wrap;
-    gap: var(--space-lg);
+    display: grid;
+    grid-template-columns: 1.2fr 0.8fr 1fr;
+    gap: var(--space-2xl);
   }
 
-  .footer-brand {
-    display: flex;
-    align-items: center;
-    gap: var(--space-md);
+  .footer-col { display: flex; flex-direction: column; gap: var(--space-sm); }
+
+  .footer-col-title {
+    font-size: var(--text-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--accent-primary);
+    margin-bottom: var(--space-sm);
   }
 
   .footer-logo {
@@ -52,34 +85,76 @@ const year = new Date().getFullYear();
 
   .footer-logo-img {
     display: block;
-    height: 22px;
+    height: 24px;
     width: auto;
   }
 
   .footer-tagline {
     font-size: var(--text-sm);
+    color: var(--text-muted);
+  }
+
+  .footer-byline {
+    font-size: var(--text-xs);
     color: var(--text-subtle);
   }
 
-  .footer-links {
-    display: flex;
-    gap: var(--space-lg);
+  .footer-byline a {
+    color: var(--text-muted);
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    transition: color var(--transition);
   }
 
-  .footer-links a {
+  .footer-byline a:hover {
+    color: var(--accent-primary);
+  }
+
+  .footer-nav {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+
+  .footer-nav a {
     font-size: var(--text-sm);
     color: var(--text-muted);
     transition: color var(--transition);
   }
 
-  .footer-links a:hover { color: var(--text); }
+  .footer-nav a:hover { color: var(--text); }
+
+  .footer-stats {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+    font-size: var(--text-xs);
+    color: var(--text-subtle);
+  }
+
+  .stat-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .stat-item svg {
+    opacity: 0.6;
+  }
+
+  .stat-num {
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-weight: 600;
+    color: var(--text-muted);
+  }
 
   .footer-meta {
     display: flex;
     align-items: center;
     gap: var(--space-md);
-    font-size: var(--text-sm);
+    font-size: var(--text-xs);
     color: var(--text-subtle);
+    margin-top: var(--space-md);
   }
 
   .footer-mit {
@@ -98,9 +173,47 @@ const year = new Date().getFullYear();
 
   @media (max-width: 768px) {
     .footer-inner {
-      flex-direction: column;
+      grid-template-columns: 1fr;
       text-align: center;
+      gap: var(--space-xl);
     }
-    .footer-links { flex-wrap: wrap; justify-content: center; }
+    .footer-col { align-items: center; }
+    .footer-meta { justify-content: center; }
   }
 </style>
+
+<script is:inline>
+(function() {
+  function updateDOM(data) {
+    var today = document.getElementById('visitors-today');
+    var total = document.getElementById('visitors-total');
+    if (today) today.textContent = (data.today || 0).toLocaleString();
+    if (total) total.textContent = (data.total || 0).toLocaleString();
+  }
+
+  function loadVisitors() {
+    // One increment per session
+    if (!sessionStorage.getItem('ogcops-counted')) {
+      fetch('/api/visitors', { method: 'POST' })
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+          sessionStorage.setItem('ogcops-counted', '1');
+          updateDOM(data);
+        })
+        .catch(function(e) { console.warn('Visitor counter error:', e); });
+    } else {
+      fetch('/api/visitors')
+        .then(function(r) { return r.json(); })
+        .then(updateDOM)
+        .catch(function(e) { console.warn('Visitor counter error:', e); });
+    }
+  }
+
+  // Ensure DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', loadVisitors);
+  } else {
+    loadVisitors();
+  }
+})();
+</script>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,8 @@
 ---
+import { getStarCount, formatStarCount } from '../lib/github-stars';
+
 const currentPath = Astro.url.pathname;
+const starCount = await getStarCount();
 
 const navItems = [
   { href: '/', label: 'Home' },
@@ -15,6 +18,7 @@ const navItems = [
     <a href="/" class="header-logo">
       <img src="/logo.svg" alt="OGCOPS" class="logo-img" width="120" height="30" />
       <span class="logo-fallback" aria-hidden="true"><span class="logo-text">OG</span><span class="logo-accent">COPS</span></span>
+      <span class="oss-badge">Open Source</span>
     </a>
 
     <div class="header-links">
@@ -27,7 +31,8 @@ const navItems = [
         </a>
       ))}
       <a href="https://github.com/codercops/ogcops" target="_blank" rel="noopener" class="nav-link nav-github">
-        GitHub
+        <svg class="github-icon" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>
+        {starCount !== null && <span class="star-count">{formatStarCount(starCount)}</span>}
       </a>
     </div>
 
@@ -40,10 +45,14 @@ const navItems = [
 <!-- Mobile Menu -->
 <div class="mobile-menu" id="mobile-menu">
   <div class="mobile-menu-inner">
-    {navItems.map((item) => (
-      <a href={item.href} class="mobile-menu-link">{item.label}</a>
+    {navItems.map((item, i) => (
+      <a href={item.href} class="mobile-menu-link" style={`--delay: ${i * 50}ms`}>{item.label}</a>
     ))}
-    <a href="https://github.com/codercops/ogcops" target="_blank" rel="noopener" class="mobile-menu-link">GitHub</a>
+    <a href="https://github.com/codercops/ogcops" target="_blank" rel="noopener" class="mobile-menu-link mobile-github-link" style={`--delay: ${navItems.length * 50}ms`}>
+      <svg class="github-icon" viewBox="0 0 16 16" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>
+      Star on GitHub
+      {starCount !== null && <span class="star-count">{formatStarCount(starCount)}</span>}
+    </a>
   </div>
 </div>
 
@@ -62,10 +71,19 @@ const navItems = [
     position: sticky;
     top: 0;
     z-index: 100;
-    background: var(--bg);
-    border-bottom: 1px solid var(--border);
-    backdrop-filter: blur(12px);
-    background: rgba(var(--bg), 0.8);
+    background: var(--bg-frosted);
+    backdrop-filter: saturate(180%) blur(20px);
+    -webkit-backdrop-filter: saturate(180%) blur(20px);
+  }
+
+  .header::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent 0%, var(--border) 20%, var(--accent-primary-muted) 50%, var(--border) 80%, transparent 100%);
   }
 
   .header-nav {
@@ -80,11 +98,12 @@ const navItems = [
     flex-shrink: 0;
     display: flex;
     align-items: center;
+    gap: var(--space-sm);
   }
 
   .logo-img {
     display: block;
-    height: 26px;
+    height: 28px;
     width: auto;
   }
 
@@ -93,10 +112,25 @@ const navItems = [
   .logo-text { color: var(--text); }
   .logo-accent { color: var(--accent-primary); }
 
+  .oss-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    color: var(--accent-primary);
+    background: var(--accent-primary-subtle, rgba(224, 122, 95, 0.1));
+    border: 1px solid rgba(224, 122, 95, 0.2);
+    border-radius: var(--radius-full, 999px);
+    white-space: nowrap;
+    line-height: 1.4;
+  }
+
   .header-links {
     display: flex;
     align-items: center;
-    gap: var(--space-lg);
+    gap: 4px;
     margin-left: auto;
   }
 
@@ -104,24 +138,49 @@ const navItems = [
     font-size: var(--text-sm);
     font-weight: 500;
     color: var(--text-muted);
-    transition: color var(--transition);
+    padding: 6px 12px;
+    border-radius: var(--radius);
+    transition: color var(--transition), background-color var(--transition);
     white-space: nowrap;
   }
 
-  .nav-link:hover, .nav-link.active {
+  .nav-link:hover {
     color: var(--text);
+    background-color: var(--bg-surface);
+  }
+
+  .nav-link.active {
+    color: var(--text);
+    background-color: var(--bg-surface);
   }
 
   .nav-github {
-    padding: var(--space-xs) var(--space-md);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-left: 8px;
+    padding: 6px 12px;
     border: 1px solid var(--border);
     border-radius: var(--radius);
     font-size: var(--text-xs);
+    background: var(--bg-elevated);
+    box-shadow: var(--shadow-xs);
   }
 
   .nav-github:hover {
     border-color: var(--border-strong);
     background: var(--bg-surface);
+    box-shadow: var(--shadow-md), 0 0 12px rgba(224, 122, 95, 0.08);
+  }
+
+  .github-icon {
+    flex-shrink: 0;
+  }
+
+  .star-count {
+    font-weight: 600;
+    font-size: var(--text-xs);
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
   }
 
   .mobile-menu-btn {
@@ -154,14 +213,20 @@ const navItems = [
     display: none;
     position: fixed;
     inset: var(--nav-height) 0 0 0;
-    background: var(--bg);
+    background: var(--bg-frosted);
+    backdrop-filter: saturate(180%) blur(20px);
+    -webkit-backdrop-filter: saturate(180%) blur(20px);
     z-index: 99;
     padding: var(--space-xl);
-    transform: translateY(-100%);
-    transition: transform var(--transition);
+    opacity: 0;
+    transform: translateY(-8px);
+    transition: opacity var(--transition), transform var(--transition);
   }
 
-  .mobile-menu.open { transform: translateY(0); }
+  .mobile-menu.open {
+    opacity: 1;
+    transform: translateY(0);
+  }
 
   .mobile-menu-link {
     display: block;
@@ -170,11 +235,35 @@ const navItems = [
     font-weight: 500;
     color: var(--text);
     border-bottom: 1px solid var(--border);
+    opacity: 0;
+    transform: translateY(-4px);
+    transition: opacity 0.3s ease var(--delay, 0ms), transform 0.3s ease var(--delay, 0ms);
+  }
+
+  .mobile-menu.open .mobile-menu-link {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .mobile-github-link {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+  }
+
+  .mobile-github-link .star-count {
+    margin-left: auto;
+    padding: 2px 8px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    font-size: var(--text-xs);
   }
 
   @media (max-width: 768px) {
     .header-links { display: none; }
     .mobile-menu-btn { display: flex; }
     .mobile-menu { display: block; }
+    .oss-badge { display: none; }
   }
 </style>

--- a/src/components/StarBanner.astro
+++ b/src/components/StarBanner.astro
@@ -1,0 +1,205 @@
+<!-- Star-repo banner: shows after 10s on first visit, bottom-right card -->
+<div id="star-banner" class="star-banner" aria-hidden="true">
+  <div class="star-banner-content">
+    <div class="star-banner-header">
+      <svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" class="star-banner-icon"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>
+      <span class="star-banner-title">Enjoying OGCOPS?</span>
+    </div>
+    <p class="star-banner-text">Star us on GitHub to help others discover this tool</p>
+    <div class="star-banner-actions">
+      <a href="https://github.com/codercops/ogcops" target="_blank" rel="noopener" class="star-banner-btn star-banner-primary" id="star-banner-star">
+        <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z"></path></svg>
+        Star on GitHub
+      </a>
+      <button type="button" class="star-banner-btn star-banner-ghost" id="star-banner-dismiss">Maybe later</button>
+    </div>
+  </div>
+  <button type="button" class="star-banner-close" id="star-banner-close" aria-label="Close">
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="1" y1="1" x2="13" y2="13"/><line x1="13" y1="1" x2="1" y2="13"/></svg>
+  </button>
+</div>
+
+<script is:inline>
+(function() {
+  var STORAGE_KEY = 'ogcops-star-banner';
+
+  function shouldShow() {
+    try {
+      var data = localStorage.getItem(STORAGE_KEY);
+      if (!data) return true;
+      var parsed = JSON.parse(data);
+      if (parsed.permanent) return false;
+      // 7-day expiry for "maybe later"
+      if (parsed.until && Date.now() < parsed.until) return false;
+      return true;
+    } catch { return true; }
+  }
+
+  function dismissPermanent() {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify({ permanent: true })); } catch {}
+  }
+
+  function dismissTemporary() {
+    var sevenDays = 7 * 24 * 60 * 60 * 1000;
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify({ until: Date.now() + sevenDays })); } catch {}
+  }
+
+  function hideBanner() {
+    var banner = document.getElementById('star-banner');
+    if (banner) {
+      banner.classList.remove('star-banner-visible');
+      banner.setAttribute('aria-hidden', 'true');
+    }
+  }
+
+  if (!shouldShow()) return;
+
+  setTimeout(function() {
+    var banner = document.getElementById('star-banner');
+    if (!banner) return;
+
+    banner.classList.add('star-banner-visible');
+    banner.setAttribute('aria-hidden', 'false');
+
+    document.getElementById('star-banner-star')?.addEventListener('click', function() {
+      dismissPermanent();
+      hideBanner();
+    });
+
+    document.getElementById('star-banner-dismiss')?.addEventListener('click', function() {
+      dismissTemporary();
+      hideBanner();
+    });
+
+    document.getElementById('star-banner-close')?.addEventListener('click', function() {
+      dismissTemporary();
+      hideBanner();
+    });
+  }, 10000);
+})();
+</script>
+
+<style>
+  .star-banner {
+    position: fixed;
+    bottom: var(--space-xl, 24px);
+    right: var(--space-xl, 24px);
+    z-index: 9000;
+    width: 300px;
+    background: var(--bg-elevated, #fff);
+    border: 1px solid var(--border, #e5e5e5);
+    border-radius: var(--radius-lg, 12px);
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12);
+    padding: var(--space-lg, 16px);
+    opacity: 0;
+    transform: translateY(20px);
+    pointer-events: none;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+  }
+
+  .star-banner-visible {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  .star-banner-close {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    background: none;
+    border: none;
+    color: var(--text-muted, #999);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: var(--radius-sm, 4px);
+    transition: color var(--transition, 0.15s ease);
+  }
+
+  .star-banner-close:hover {
+    color: var(--text, #333);
+  }
+
+  .star-banner-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm, 8px);
+    margin-bottom: var(--space-xs, 4px);
+  }
+
+  .star-banner-icon {
+    color: var(--text, #333);
+  }
+
+  .star-banner-title {
+    font-size: var(--text-base, 16px);
+    font-weight: 600;
+    color: var(--text, #333);
+  }
+
+  .star-banner-text {
+    font-size: var(--text-sm, 14px);
+    color: var(--text-muted, #666);
+    line-height: 1.5;
+    margin-bottom: var(--space-md, 12px);
+  }
+
+  .star-banner-actions {
+    display: flex;
+    gap: var(--space-sm, 8px);
+  }
+
+  .star-banner-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 14px;
+    font-size: var(--text-sm, 14px);
+    font-weight: 500;
+    border-radius: var(--radius, 8px);
+    cursor: pointer;
+    transition: all var(--transition, 0.15s ease);
+    text-decoration: none;
+    border: none;
+  }
+
+  .star-banner-primary {
+    background: var(--accent-primary, #E07A5F);
+    color: #fff;
+  }
+
+  .star-banner-primary:hover {
+    opacity: 0.9;
+    transform: translateY(-1px);
+  }
+
+  .star-banner-ghost {
+    background: none;
+    color: var(--text-muted, #666);
+    padding: 8px 12px;
+  }
+
+  .star-banner-ghost:hover {
+    color: var(--text, #333);
+    background: var(--bg-surface, #f5f5f5);
+  }
+
+  @media (max-width: 480px) {
+    .star-banner {
+      left: var(--space-md, 12px);
+      right: var(--space-md, 12px);
+      width: auto;
+      bottom: var(--space-md, 12px);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .star-banner {
+      transition: opacity 0.1s ease;
+      transform: none;
+    }
+    .star-banner-visible {
+      transform: none;
+    }
+  }
+</style>

--- a/src/components/Toast.astro
+++ b/src/components/Toast.astro
@@ -1,0 +1,83 @@
+<!-- Global toast container + showToast() function -->
+<div id="toast-container" class="toast-container"></div>
+
+<script is:inline>
+  window.showToast = function(message, type, duration) {
+    type = type || 'info';
+    duration = duration || 3000;
+    var container = document.getElementById('toast-container');
+    if (!container) return;
+
+    var toast = document.createElement('div');
+    toast.className = 'toast toast-' + type;
+    toast.textContent = message;
+    container.appendChild(toast);
+
+    // Trigger entrance animation
+    requestAnimationFrame(function() {
+      toast.classList.add('toast-visible');
+    });
+
+    setTimeout(function() {
+      toast.classList.remove('toast-visible');
+      toast.addEventListener('transitionend', function() {
+        toast.remove();
+      });
+    }, duration);
+  };
+</script>
+
+<style>
+  .toast-container {
+    position: fixed;
+    bottom: var(--space-xl, 24px);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10000;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-sm, 8px);
+    pointer-events: none;
+  }
+
+  .toast-container :global(.toast) {
+    padding: 10px 20px;
+    background: var(--text, #1a1a1a);
+    color: var(--bg, #fff);
+    font-size: var(--text-sm, 14px);
+    font-weight: 500;
+    border-radius: var(--radius-full, 999px);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
+    opacity: 0;
+    transform: translateY(12px);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    pointer-events: auto;
+    white-space: nowrap;
+  }
+
+  .toast-container :global(.toast-visible) {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .toast-container :global(.toast-success) {
+    background: #16a34a;
+    color: #fff;
+  }
+
+  .toast-container :global(.toast-error) {
+    background: #dc2626;
+    color: #fff;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .toast-container :global(.toast) {
+      transition: opacity 0.1s ease;
+      transform: none;
+    }
+    .toast-container :global(.toast-visible) {
+      transform: none;
+    }
+  }
+</style>

--- a/src/components/editor/ExportBar.tsx
+++ b/src/components/editor/ExportBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 
 interface ExportBarProps {
   apiUrl: string;
@@ -7,14 +7,25 @@ interface ExportBarProps {
   templateId: string;
 }
 
+declare global {
+  interface Window {
+    showToast?: (message: string, type?: string, duration?: number) => void;
+  }
+}
+
 export function ExportBar({ apiUrl, downloadUrl, params, templateId }: ExportBarProps) {
   const [downloading, setDownloading] = useState(false);
   const [copied, setCopied] = useState<string | null>(null);
+  const downloadRef = useRef(downloadUrl);
+  const apiUrlRef = useRef(apiUrl);
+
+  downloadRef.current = downloadUrl;
+  apiUrlRef.current = apiUrl;
 
   const handleDownload = useCallback(async () => {
     setDownloading(true);
     try {
-      const res = await fetch(downloadUrl);
+      const res = await fetch(downloadRef.current);
       if (!res.ok) throw new Error('Download failed');
       const blob = await res.blob();
       const url = URL.createObjectURL(blob);
@@ -25,17 +36,20 @@ export function ExportBar({ apiUrl, downloadUrl, params, templateId }: ExportBar
       a.click();
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
+      window.showToast?.('Downloaded!', 'success');
     } catch (err) {
       console.error('Download error:', err);
+      window.showToast?.('Download failed', 'error');
     } finally {
       setDownloading(false);
     }
-  }, [apiUrl, templateId]);
+  }, [templateId]);
 
   const copyToClipboard = useCallback(async (text: string, label: string) => {
     try {
       await navigator.clipboard.writeText(text);
       setCopied(label);
+      window.showToast?.(label === 'url' ? 'URL copied to clipboard!' : 'Meta tags copied!', 'success');
       setTimeout(() => setCopied(null), 2000);
     } catch {
       // Fallback
@@ -46,9 +60,33 @@ export function ExportBar({ apiUrl, downloadUrl, params, templateId }: ExportBar
       document.execCommand('copy');
       document.body.removeChild(ta);
       setCopied(label);
+      window.showToast?.(label === 'url' ? 'URL copied to clipboard!' : 'Meta tags copied!', 'success');
       setTimeout(() => setCopied(null), 2000);
     }
   }, []);
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      const mod = e.metaKey || e.ctrlKey;
+      if (!mod) return;
+
+      // Ctrl/Cmd+S → Download PNG
+      if (e.key === 's' && !e.shiftKey) {
+        e.preventDefault();
+        handleDownload();
+      }
+
+      // Ctrl/Cmd+Shift+C → Copy API URL
+      if (e.key === 'C' && e.shiftKey) {
+        e.preventDefault();
+        copyToClipboard(apiUrlRef.current, 'url');
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [handleDownload, copyToClipboard]);
 
   const metaTags = [
     `<meta property="og:image" content="${apiUrl}" />`,
@@ -64,28 +102,31 @@ export function ExportBar({ apiUrl, downloadUrl, params, templateId }: ExportBar
 
   return (
     <div className="export-bar">
-      <button
-        type="button"
-        className="export-btn export-btn-primary"
-        onClick={handleDownload}
-        disabled={downloading}
-      >
-        {downloading ? 'Generating...' : 'Download PNG'}
-      </button>
-      <button
-        type="button"
-        className="export-btn export-btn-ghost"
-        onClick={() => copyToClipboard(apiUrl, 'url')}
-      >
-        {copied === 'url' ? 'Copied!' : 'Copy URL'}
-      </button>
-      <button
-        type="button"
-        className="export-btn export-btn-ghost"
-        onClick={() => copyToClipboard(metaTags, 'meta')}
-      >
-        {copied === 'meta' ? 'Copied!' : 'Copy Meta Tags'}
-      </button>
+      <div className="export-buttons">
+        <button
+          type="button"
+          className="export-btn export-btn-primary"
+          onClick={handleDownload}
+          disabled={downloading}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+          {downloading ? 'Generating...' : 'Download PNG'}
+        </button>
+        <button
+          type="button"
+          className="export-btn export-btn-ghost"
+          onClick={() => copyToClipboard(apiUrl, 'url')}
+        >
+          {copied === 'url' ? 'Copied!' : 'Copy URL'}
+        </button>
+        <button
+          type="button"
+          className="export-btn export-btn-ghost"
+          onClick={() => copyToClipboard(metaTags, 'meta')}
+        >
+          {copied === 'meta' ? 'Copied!' : 'Copy Meta Tags'}
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/editor/TemplateThumbnail.tsx
+++ b/src/components/editor/TemplateThumbnail.tsx
@@ -18,8 +18,8 @@ export function TemplateThumbnail({ id, name, isActive, onClick }: TemplateThumb
           src={`/api/templates/${id}/thumbnail.png`}
           alt={name}
           loading="lazy"
-          width={280}
-          height={147}
+          width={600}
+          height={315}
         />
       </div>
       <span className="template-thumb-name">{name}</span>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,10 @@
 ---
+import { ClientRouter } from 'astro:transitions';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+import Toast from '../components/Toast.astro';
+import StarBanner from '../components/StarBanner.astro';
+import BackToTop from '../components/BackToTop.astro';
 import '../styles/global.css';
 
 interface Props {
@@ -38,8 +42,7 @@ const fullTitle = title === 'OGCOPS' ? title : `${title} | ${siteName}`;
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
-    <meta name="theme-color" content="#0C0A09" media="(prefers-color-scheme: dark)" />
-    <meta name="theme-color" content="#FAFAF9" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#FAFAFA" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
@@ -63,6 +66,9 @@ const fullTitle = title === 'OGCOPS' ? title : `${title} | ${siteName}`;
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet" />
+
+    <!-- View Transitions -->
+    <ClientRouter />
 
     <!-- Google Analytics (same property as main site) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-GLYL9J6QYX"></script>
@@ -100,11 +106,14 @@ const fullTitle = title === 'OGCOPS' ? title : `${title} | ${siteName}`;
     <slot name="head" />
   </head>
   <body>
-    <Header />
-    <main>
+    <Header transition:persist />
+    <main transition:animate="fade">
       <slot />
     </main>
     <Footer />
+    <Toast />
+    <StarBanner />
+    <BackToTop />
   </body>
 </html>
 

--- a/src/lib/github-stars.ts
+++ b/src/lib/github-stars.ts
@@ -1,0 +1,31 @@
+const REPO = 'codercops/ogcops';
+const CACHE_TTL = 60 * 60 * 1000; // 1 hour
+
+let cached: { count: number; timestamp: number } | null = null;
+
+export async function getStarCount(): Promise<number | null> {
+  if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+    return cached.count;
+  }
+
+  try {
+    const res = await fetch(`https://api.github.com/repos/${REPO}`, {
+      headers: { Accept: 'application/vnd.github.v3+json' },
+    });
+    if (!res.ok) return cached?.count ?? null;
+
+    const data = await res.json();
+    const count = data.stargazers_count ?? 0;
+    cached = { count, timestamp: Date.now() };
+    return count;
+  } catch {
+    return cached?.count ?? null;
+  }
+}
+
+export function formatStarCount(count: number): string {
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1).replace(/\.0$/, '')}k`;
+  }
+  return String(count);
+}

--- a/src/lib/og-engine.ts
+++ b/src/lib/og-engine.ts
@@ -48,6 +48,8 @@ export interface RenderOptions {
   width?: number;
   height?: number;
   format?: 'png' | 'svg';
+  /** If set, scales the final PNG to this width (maintaining aspect ratio). */
+  scaleDown?: number;
 }
 
 /**
@@ -75,7 +77,7 @@ export async function renderToPng(
   element: SatoriElement,
   options: RenderOptions = {}
 ): Promise<ArrayBuffer> {
-  const { width = 1200, height = 630 } = options;
+  const { width = 1200, height = 630, scaleDown } = options;
 
   await ensureWasmInitialized();
 
@@ -83,8 +85,9 @@ export async function renderToPng(
 
   // Serialize access to Resvg — the WASM module is single-threaded
   return withRenderLock(async () => {
+    const outputWidth = scaleDown ?? width;
     const resvg = new Resvg(svg, {
-      fitTo: { mode: 'width', value: width },
+      fitTo: { mode: 'width', value: outputWidth },
     });
     const pngData = resvg.render();
     const pngBytes = pngData.asPng();

--- a/src/lib/upstash.ts
+++ b/src/lib/upstash.ts
@@ -1,0 +1,60 @@
+const UPSTASH_URL = import.meta.env.UPSTASH_REDIS_REST_URL;
+const UPSTASH_TOKEN = import.meta.env.UPSTASH_REDIS_REST_TOKEN;
+
+async function redis(command: string[]): Promise<any> {
+  const res = await fetch(UPSTASH_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${UPSTASH_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(command),
+  });
+  if (!res.ok) throw new Error(`Upstash error: ${res.status}`);
+  const data = await res.json();
+  return data.result;
+}
+
+/**
+ * Increments visitor count and returns today + total in a single EVAL command.
+ * Uses one Redis command per call to stay within Upstash free tier (10K/day).
+ */
+export async function incrementVisitors(site: string): Promise<{ today: number; total: number }> {
+  const todayKey = `${site}:today:${new Date().toISOString().slice(0, 10)}`;
+  const totalKey = `${site}:total`;
+  const ttl = 90 * 24 * 60 * 60; // 90 days TTL on daily keys
+
+  const script = `
+    local today = redis.call('INCR', KEYS[1])
+    if today == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end
+    local total = redis.call('INCR', KEYS[2])
+    return {today, total}
+  `;
+
+  const result = await redis(['EVAL', script, '2', todayKey, totalKey, String(ttl)]);
+  return { today: result[0], total: result[1] };
+}
+
+/**
+ * Returns current counts without incrementing.
+ */
+export async function getVisitors(site: string): Promise<{ today: number; total: number }> {
+  const todayKey = `${site}:today:${new Date().toISOString().slice(0, 10)}`;
+  const totalKey = `${site}:total`;
+
+  const res = await fetch(`${UPSTASH_URL}/pipeline`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${UPSTASH_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify([['GET', todayKey], ['GET', totalKey]]),
+  });
+
+  if (!res.ok) return { today: 0, total: 0 };
+  const data = await res.json();
+  return {
+    today: parseInt(data[0]?.result || '0', 10),
+    total: parseInt(data[1]?.result || '0', 10),
+  };
+}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -6,13 +6,33 @@ export const prerender = true;
 
 <Layout title="404 — Page Not Found" noindex>
   <section class="error-page">
-    <div class="container">
-      <span class="error-code">404</span>
+    <div class="error-bg-shapes">
+      <div class="error-shape error-shape-1"></div>
+      <div class="error-shape error-shape-2"></div>
+      <div class="error-shape error-shape-3"></div>
+    </div>
+    <div class="container error-content">
+      <!-- SVG Illustration -->
+      <div class="error-illustration">
+        <svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="10" y="20" width="100" height="75" rx="8" stroke="var(--border-strong)" stroke-width="2" fill="var(--bg-surface)"/>
+          <rect x="10" y="20" width="100" height="20" rx="8" fill="var(--bg-subtle)" stroke="var(--border-strong)" stroke-width="2"/>
+          <circle cx="26" cy="30" r="4" fill="#FF5F57"/>
+          <circle cx="38" cy="30" r="4" fill="#FEBC2E"/>
+          <circle cx="50" cy="30" r="4" fill="#28C840"/>
+          <path d="M45 65 L55 75 M55 65 L45 75" stroke="var(--accent-primary)" stroke-width="3" stroke-linecap="round"/>
+          <path d="M65 65 L75 75 M75 65 L65 75" stroke="var(--accent-primary)" stroke-width="3" stroke-linecap="round"/>
+          <path d="M42 85 C48 82, 52 82, 55 83 C58 84, 62 84, 65 83 C68 82, 72 82, 78 85" stroke="var(--border-strong)" stroke-width="2" stroke-linecap="round" fill="none"/>
+        </svg>
+      </div>
+
+      <span class="error-code text-gradient">404</span>
       <h1>Page Not Found</h1>
       <p>The page you're looking for doesn't exist or has been moved.</p>
       <div class="error-ctas">
-        <a href="/" class="btn btn-primary">Go Home</a>
-        <a href="/create" class="btn btn-outline">Create OG Image</a>
+        <a href="/" class="btn btn-primary btn-lg">Go Home</a>
+        <a href="/templates" class="btn btn-outline btn-lg">Browse Templates</a>
+        <a href="/api-docs" class="btn btn-ghost">Try the API</a>
       </div>
     </div>
   </section>
@@ -20,34 +40,98 @@ export const prerender = true;
 
 <style>
   .error-page {
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
-    min-height: 60vh;
+    min-height: 70vh;
     text-align: center;
+    overflow: hidden;
+  }
+
+  .error-bg-shapes {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    overflow: hidden;
+  }
+
+  .error-shape {
+    position: absolute;
+    border-radius: 50%;
+    opacity: 0.5;
+  }
+
+  .error-shape-1 {
+    width: 200px;
+    height: 200px;
+    background: radial-gradient(circle, var(--accent-primary-subtle) 0%, transparent 70%);
+    top: 10%;
+    right: 15%;
+    animation: float 6s ease-in-out infinite;
+  }
+
+  .error-shape-2 {
+    width: 150px;
+    height: 150px;
+    background: radial-gradient(circle, rgba(224, 122, 95, 0.08) 0%, transparent 70%);
+    bottom: 20%;
+    left: 10%;
+    animation: float 8s ease-in-out infinite reverse;
+  }
+
+  .error-shape-3 {
+    width: 100px;
+    height: 100px;
+    background: radial-gradient(circle, var(--accent-primary-subtle) 0%, transparent 70%);
+    top: 50%;
+    left: 60%;
+    animation: float 7s ease-in-out infinite;
+  }
+
+  .error-content {
+    position: relative;
+    z-index: 1;
+  }
+
+  .error-illustration {
+    margin-bottom: var(--space-xl);
+  }
+
+  .error-illustration svg {
+    margin: 0 auto;
   }
 
   .error-code {
     display: block;
-    font-size: 8rem;
-    font-weight: 700;
-    color: var(--border-strong);
+    font-size: 6rem;
+    font-weight: 800;
     line-height: 1;
-    margin-bottom: var(--space-lg);
+    margin-bottom: var(--space-md);
+    letter-spacing: -0.04em;
   }
 
   .error-page h1 {
+    font-size: var(--text-3xl);
     margin-bottom: var(--space-md);
   }
 
   .error-page p {
     color: var(--text-muted);
+    font-size: var(--text-lg);
     margin: 0 auto var(--space-xl);
+    max-width: 400px;
   }
 
   .error-ctas {
     display: flex;
     gap: var(--space-md);
     justify-content: center;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .error-shape { animation: none; }
   }
 </style>

--- a/src/pages/api-docs.astro
+++ b/src/pages/api-docs.astro
@@ -8,11 +8,26 @@ import '@/styles/api-docs.css';
     <!-- Sidebar -->
     <aside class="api-sidebar">
       <nav class="api-sidebar-nav">
-        <a href="#overview" class="api-sidebar-link active">Overview</a>
-        <a href="#generate" class="api-sidebar-link">Generate Image</a>
-        <a href="#preview" class="api-sidebar-link">Preview URL</a>
-        <a href="#templates" class="api-sidebar-link">List Templates</a>
-        <a href="#thumbnail" class="api-sidebar-link">Thumbnails</a>
+        <a href="#overview" class="api-sidebar-link active">
+          <svg class="api-sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
+          Overview
+        </a>
+        <a href="#generate" class="api-sidebar-link">
+          <svg class="api-sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>
+          Generate Image
+        </a>
+        <a href="#preview" class="api-sidebar-link">
+          <svg class="api-sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
+          Preview URL
+        </a>
+        <a href="#templates" class="api-sidebar-link">
+          <svg class="api-sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="7" height="7" x="3" y="3" rx="1"/><rect width="7" height="7" x="14" y="3" rx="1"/><rect width="7" height="7" x="14" y="14" rx="1"/><rect width="7" height="7" x="3" y="14" rx="1"/></svg>
+          List Templates
+        </a>
+        <a href="#thumbnail" class="api-sidebar-link">
+          <svg class="api-sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg>
+          Thumbnails
+        </a>
       </nav>
     </aside>
 
@@ -29,6 +44,7 @@ import '@/styles/api-docs.css';
         <div class="endpoint-header">
           <span class="endpoint-method">GET</span>
           <span class="endpoint-path">/api/og</span>
+          <a href="#generate" class="section-anchor" aria-label="Link to this section">#</a>
         </div>
         <p class="endpoint-desc">Generate an OG image as PNG. Returns image/png with Cache-Control headers.</p>
 
@@ -91,13 +107,21 @@ import '@/styles/api-docs.css';
 
         <h4>Examples</h4>
         <div class="code-block">
-          <div class="code-block-header"><span>curl</span></div>
+          <div class="code-block-header">
+            <div class="code-block-dots"><span class="code-block-dot"></span><span class="code-block-dot"></span><span class="code-block-dot"></span></div>
+            <span>curl</span>
+            <button class="code-block-copy" data-copy type="button">Copy</button>
+          </div>
           <pre class="code-block-body"><code>curl "https://og.codercops.com/api/og?title=Hello+World&template=blog-minimal-dark" \
   --output og-image.png</code></pre>
         </div>
 
         <div class="code-block">
-          <div class="code-block-header"><span>JavaScript</span></div>
+          <div class="code-block-header">
+            <div class="code-block-dots"><span class="code-block-dot"></span><span class="code-block-dot"></span><span class="code-block-dot"></span></div>
+            <span>JavaScript</span>
+            <button class="code-block-copy" data-copy type="button">Copy</button>
+          </div>
           <pre class="code-block-body"><code>{`const params = new URLSearchParams({
   template: 'blog-minimal-dark',
   title: 'Hello World',
@@ -111,7 +135,11 @@ const imageUrl = \`https://og.codercops.com/api/og?\${params}\`;
         </div>
 
         <div class="code-block">
-          <div class="code-block-header"><span>Python</span></div>
+          <div class="code-block-header">
+            <div class="code-block-dots"><span class="code-block-dot"></span><span class="code-block-dot"></span><span class="code-block-dot"></span></div>
+            <span>Python</span>
+            <button class="code-block-copy" data-copy type="button">Copy</button>
+          </div>
           <pre class="code-block-body"><code>{`import requests
 
 response = requests.get("https://og.codercops.com/api/og", params={
@@ -130,6 +158,7 @@ with open("og-image.png", "wb") as f:
         <div class="endpoint-header">
           <span class="endpoint-method">GET</span>
           <span class="endpoint-path">/api/preview</span>
+          <a href="#preview" class="section-anchor" aria-label="Link to this section">#</a>
         </div>
         <p class="endpoint-desc">Fetch and analyze meta tags from a URL. Returns JSON with meta tags, analysis score, and per-platform preview data for 8 platforms.</p>
 
@@ -149,9 +178,13 @@ with open("og-image.png", "wb") as f:
         </table>
 
         <h4>Response</h4>
-        <div class="code-block">
-          <div class="code-block-header"><span>JSON Response</span></div>
-          <pre class="code-block-body"><code>{`{
+        <div class="code-block code-block-collapsible">
+          <div class="code-block-header">
+            <div class="code-block-dots"><span class="code-block-dot"></span><span class="code-block-dot"></span><span class="code-block-dot"></span></div>
+            <span>JSON Response</span>
+            <button class="code-block-copy" data-copy type="button">Copy</button>
+          </div>
+          <pre class="code-block-body" id="preview-response"><code>{`{
   "url": "https://example.com",
   "meta": {
     "title": "Example",
@@ -185,11 +218,16 @@ with open("og-image.png", "wb") as f:
         <div class="endpoint-header">
           <span class="endpoint-method">GET</span>
           <span class="endpoint-path">/api/templates</span>
+          <a href="#templates" class="section-anchor" aria-label="Link to this section">#</a>
         </div>
         <p class="endpoint-desc">List all available templates with their fields, defaults, and thumbnail URLs.</p>
 
         <div class="code-block">
-          <div class="code-block-header"><span>curl</span></div>
+          <div class="code-block-header">
+            <div class="code-block-dots"><span class="code-block-dot"></span><span class="code-block-dot"></span><span class="code-block-dot"></span></div>
+            <span>curl</span>
+            <button class="code-block-copy" data-copy type="button">Copy</button>
+          </div>
           <pre class="code-block-body"><code>curl "https://og.codercops.com/api/templates"</code></pre>
         </div>
       </div>
@@ -199,14 +237,58 @@ with open("og-image.png", "wb") as f:
         <div class="endpoint-header">
           <span class="endpoint-method">GET</span>
           <span class="endpoint-path">/api/templates/&#123;id&#125;/thumbnail.png</span>
+          <a href="#thumbnail" class="section-anchor" aria-label="Link to this section">#</a>
         </div>
         <p class="endpoint-desc">Get a 600x315 thumbnail preview of a template with its default values. Cached for 7 days.</p>
 
         <div class="code-block">
-          <div class="code-block-header"><span>Example</span></div>
+          <div class="code-block-header">
+            <div class="code-block-dots"><span class="code-block-dot"></span><span class="code-block-dot"></span><span class="code-block-dot"></span></div>
+            <span>Example</span>
+            <button class="code-block-copy" data-copy type="button">Copy</button>
+          </div>
           <pre class="code-block-body"><code>https://og.codercops.com/api/templates/blog-minimal-dark/thumbnail.png</code></pre>
         </div>
       </div>
     </div>
   </div>
 </Layout>
+
+<script is:inline>
+  // Copy buttons for code blocks
+  document.querySelectorAll('[data-copy]').forEach(btn => {
+    btn.addEventListener('click', function() {
+      const codeBlock = this.closest('.code-block');
+      const code = codeBlock?.querySelector('code')?.textContent || '';
+      navigator.clipboard.writeText(code).then(() => {
+        this.textContent = 'Copied!';
+        window.showToast?.('Copied to clipboard!', 'success');
+        setTimeout(() => { this.textContent = 'Copy'; }, 2000);
+      });
+    });
+  });
+
+  // Sidebar active state on scroll
+  const sidebarLinks = document.querySelectorAll('.api-sidebar-link');
+  const sections = document.querySelectorAll('.endpoint-card[id]');
+
+  function updateSidebar() {
+    let current = '';
+    sections.forEach(section => {
+      const rect = section.getBoundingClientRect();
+      if (rect.top <= 120) current = section.id;
+    });
+    if (!current && sections.length) current = 'overview';
+
+    sidebarLinks.forEach(link => {
+      const href = link.getAttribute('href');
+      if (href === '#' + current || (!current && href === '#overview')) {
+        link.classList.add('active');
+      } else {
+        link.classList.remove('active');
+      }
+    });
+  }
+
+  window.addEventListener('scroll', updateSidebar, { passive: true });
+</script>

--- a/src/pages/api/templates/[id]/thumbnail.png.ts
+++ b/src/pages/api/templates/[id]/thumbnail.png.ts
@@ -20,7 +20,8 @@ export const GET: APIRoute = async ({ params }) => {
     let png = thumbnailCache.get(id!);
     if (!png) {
       const element = template.render(template.defaults);
-      png = await renderToPng(element, { width: 600, height: 315 });
+      // Render at full 1200x630 so satori lays out correctly, then scale down via resvg
+      png = await renderToPng(element, { width: 1200, height: 630, scaleDown: 600 });
       thumbnailCache.set(id!, png);
     }
 

--- a/src/pages/api/visitors.ts
+++ b/src/pages/api/visitors.ts
@@ -1,0 +1,26 @@
+import type { APIRoute } from 'astro';
+import { incrementVisitors, getVisitors } from '../../lib/upstash';
+
+const SITE = 'ogcops';
+const HEADERS = {
+  'Content-Type': 'application/json',
+  'Cache-Control': 'no-store',
+};
+
+export const POST: APIRoute = async () => {
+  try {
+    const counts = await incrementVisitors(SITE);
+    return new Response(JSON.stringify(counts), { headers: HEADERS });
+  } catch {
+    return new Response(JSON.stringify({ today: 0, total: 0 }), { status: 500, headers: HEADERS });
+  }
+};
+
+export const GET: APIRoute = async () => {
+  try {
+    const counts = await getVisitors(SITE);
+    return new Response(JSON.stringify(counts), { headers: HEADERS });
+  } catch {
+    return new Response(JSON.stringify({ today: 0, total: 0 }), { status: 500, headers: HEADERS });
+  }
+};

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,22 +11,27 @@ const categoryCounts = getCategoryCounts();
 
   <!-- Hero -->
   <section class="hero">
+    <div class="hero-glow"></div>
+    <div class="hero-pattern"></div>
     <div class="container hero-inner">
       <div class="hero-content" data-animate="slide-up">
         <span class="section-label">Free & Open Source</span>
-        <h1>Free OG Image<br />Generator</h1>
+        <h1><span class="text-gradient">Free</span> OG Image<br />Generator</h1>
         <p class="hero-subtitle">
           {templateCount}+ templates. 8 platform previews. Free API. No login required.
         </p>
         <div class="hero-ctas">
-          <a href="/create" class="btn btn-primary btn-lg">Create OG Image</a>
+          <a href="/create" class="btn btn-primary btn-lg">
+            Create OG Image
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+          </a>
           <a href="/preview" class="btn btn-outline btn-lg">Check Your URL</a>
         </div>
       </div>
     </div>
   </section>
 
-  <!-- Category Grid -->
+  <!-- Category Grid — Bento Layout -->
   <section class="section">
     <div class="container">
       <div class="section-header" data-animate="fade">
@@ -34,16 +39,17 @@ const categoryCounts = getCategoryCounts();
         <h2>12 Categories, {templateCount}+ Templates</h2>
         <p class="section-subtitle">Beautiful, professional OG images for every use case.</p>
       </div>
-      <div class="grid grid-4 category-grid">
+      <div class="bento-grid">
         {ALL_CATEGORIES.map((cat, i) => {
           const meta = CATEGORY_META[cat];
           const count = categoryCounts[cat] || 0;
           return (
-            <a href={`/create/${cat}`} class="card card-category" data-animate="slide-up" data-animate-delay={String(i % 4 + 1)}>
-              <span class="cat-icon">{meta.icon}</span>
-              <h3 class="cat-name">{meta.label}</h3>
-              <span class="cat-count">{count} templates</span>
-              <p class="cat-desc">{meta.description}</p>
+            <a href={`/create/${cat}`} class="bento-card" data-animate="slide-up" data-animate-delay={String(i % 4 + 1)}>
+              <div class="bento-card-accent"></div>
+              <span class="bento-icon">{meta.icon}</span>
+              <h3 class="bento-name">{meta.label}</h3>
+              <span class="badge badge-coral">{count} templates</span>
+              <p class="bento-desc">{meta.description}</p>
             </a>
           );
         })}
@@ -54,23 +60,39 @@ const categoryCounts = getCategoryCounts();
   <!-- Feature Highlights -->
   <section class="section">
     <div class="container">
-      <div class="dashed-grid dashed-grid-2x2" data-animate="scale">
-        <div class="dashed-grid-item">
+      <div class="section-header" data-animate="fade">
+        <span class="section-label">Why OGCOPS</span>
+        <h2>Everything You Need</h2>
+      </div>
+      <div class="features-grid" data-animate="scale">
+        <div class="feature-card">
+          <div class="feature-icon-wrap">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>
+          </div>
           <span class="feature-number">{templateCount}+</span>
           <h3>Templates</h3>
           <p>Professional designs across 12 categories. Blog, SaaS, GitHub, events, and more.</p>
         </div>
-        <div class="dashed-grid-item">
+        <div class="feature-card">
+          <div class="feature-icon-wrap">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" x2="16" y1="21" y2="21"/><line x1="12" x2="12" y1="17" y2="21"/></svg>
+          </div>
           <span class="feature-number">8</span>
           <h3>Platform Previews</h3>
           <p>See how your link looks on Twitter, Facebook, LinkedIn, Discord, Slack, Reddit, WhatsApp, and Google.</p>
         </div>
-        <div class="dashed-grid-item">
+        <div class="feature-card">
+          <div class="feature-icon-wrap">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 16 4-4-4-4"/><path d="m6 8-4 4 4 4"/><path d="m14.5 4-5 16"/></svg>
+          </div>
           <span class="feature-number">Free</span>
           <h3>REST API</h3>
           <p>Generate OG images via URL. CORS-enabled. No API key required. Cache-friendly.</p>
         </div>
-        <div class="dashed-grid-item">
+        <div class="feature-card">
+          <div class="feature-icon-wrap">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
+          </div>
           <span class="feature-number">MIT</span>
           <h3>Open Source</h3>
           <p>Fork it. Self-host it. Contribute templates. Built by developers, for developers.</p>
@@ -79,28 +101,45 @@ const categoryCounts = getCategoryCounts();
     </div>
   </section>
 
-  <!-- How It Works -->
+  <!-- How It Works — Timeline -->
   <section class="section">
     <div class="container">
       <div class="section-header" data-animate="fade">
         <span class="section-label">How It Works</span>
         <h2>Three Simple Steps</h2>
       </div>
-      <div class="grid grid-3 steps-grid" data-animate="slide-up">
-        <div class="step-card">
-          <span class="step-number">1</span>
-          <h3>Pick a Template</h3>
-          <p>Browse {templateCount}+ templates across 12 categories. Filter and search to find the perfect design.</p>
+      <div class="timeline">
+        <div class="timeline-line"></div>
+        <div class="timeline-step" data-animate="slide-up" data-animate-delay="1">
+          <div class="timeline-number">1</div>
+          <div class="timeline-content">
+            <h3>Pick a Template</h3>
+            <p>Browse {templateCount}+ templates across 12 categories. Filter and search to find the perfect design.</p>
+          </div>
         </div>
-        <div class="step-card">
-          <span class="step-number">2</span>
-          <h3>Customize</h3>
-          <p>Change text, colors, and branding. Instant preview updates — no waiting for server renders.</p>
+        <div class="timeline-step" data-animate="slide-up" data-animate-delay="2">
+          <div class="timeline-number">2</div>
+          <div class="timeline-content">
+            <h3>Customize</h3>
+            <p>Change text, colors, and branding. Instant preview updates — no waiting for server renders.</p>
+          </div>
         </div>
-        <div class="step-card">
-          <span class="step-number">3</span>
-          <h3>Export</h3>
-          <p>Download PNG, copy the API URL, or grab ready-to-paste meta tags. Done in seconds.</p>
+        <div class="timeline-step" data-animate="slide-up" data-animate-delay="3">
+          <div class="timeline-number">3</div>
+          <div class="timeline-content">
+            <div class="timeline-content-inner">
+              <h3>Export</h3>
+              <p>Download PNG, copy the API URL, or grab ready-to-paste meta tags. Done in seconds.</p>
+            </div>
+            <div class="timeline-terminal">
+              <div class="timeline-terminal-header">
+                <span class="timeline-terminal-dot"></span>
+                <span class="timeline-terminal-dot"></span>
+                <span class="timeline-terminal-dot"></span>
+              </div>
+              <code class="timeline-terminal-body">curl og.codercops.com/api/og?title=Hello</code>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -110,13 +149,17 @@ const categoryCounts = getCategoryCounts();
   <section class="section">
     <div class="container">
       <div class="api-teaser" data-animate="slide-up">
-        <div class="api-teaser-code">
-          <div class="api-code-header">
-            <span class="api-code-dot"></span>
-            <span class="api-code-dot"></span>
-            <span class="api-code-dot"></span>
+        <div class="terminal">
+          <div class="terminal-header">
+            <span class="terminal-dot"></span>
+            <span class="terminal-dot"></span>
+            <span class="terminal-dot"></span>
+            <span class="terminal-title">Terminal</span>
+            <div class="terminal-actions">
+              <button class="terminal-copy-btn" id="api-copy-btn" type="button">Copy</button>
+            </div>
           </div>
-          <pre class="api-code-body"><code>curl "https://og.codercops.com/api/og?\
+          <pre class="terminal-body"><code id="api-code-content">curl "https://og.codercops.com/api/og?\
   template=blog-minimal-dark&\
   title=Hello%20World&\
   author=OGCOPS"</code></pre>
@@ -125,6 +168,20 @@ const categoryCounts = getCategoryCounts();
           <span class="section-label">Free API</span>
           <h2>Generate via URL</h2>
           <p>Use our REST API to generate OG images programmatically. No API key, no rate limits, CORS-enabled.</p>
+          <ul class="api-feature-list">
+            <li>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--accent-primary)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+              No API key required
+            </li>
+            <li>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--accent-primary)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+              CORS-enabled for browsers
+            </li>
+            <li>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--accent-primary)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+              Cache-friendly headers
+            </li>
+          </ul>
           <a href="/api-docs" class="btn btn-outline">View API Docs</a>
         </div>
       </div>
@@ -132,16 +189,22 @@ const categoryCounts = getCategoryCounts();
   </section>
 
   <!-- Open Source Banner -->
-  <section class="section">
+  <section class="section oss-section">
+    <div class="oss-bg"></div>
     <div class="container">
       <div class="oss-banner" data-animate="fade">
+        <div class="oss-icon">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
+        </div>
         <span class="section-label">Open Source</span>
         <h2>Built in Public</h2>
         <p class="section-subtitle">OGCOPS is MIT licensed. Star us on GitHub, contribute templates, or self-host.</p>
         <div class="oss-ctas">
-          <a href="https://github.com/codercops/ogcops" target="_blank" rel="noopener" class="btn btn-secondary">
+          <a href="https://github.com/codercops/ogcops" target="_blank" rel="noopener" class="btn btn-secondary btn-lg">
+            <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>
             Star on GitHub
           </a>
+          <a href="/templates" class="btn btn-outline btn-lg">Browse Templates</a>
         </div>
       </div>
     </div>
@@ -149,15 +212,55 @@ const categoryCounts = getCategoryCounts();
 
 </Layout>
 
+<script is:inline>
+  // Terminal copy button
+  document.getElementById('api-copy-btn')?.addEventListener('click', function() {
+    const code = document.getElementById('api-code-content')?.textContent || '';
+    navigator.clipboard.writeText(code).then(() => {
+      this.textContent = 'Copied!';
+      window.showToast?.('Copied to clipboard!', 'success');
+      setTimeout(() => { this.textContent = 'Copy'; }, 2000);
+    });
+  });
+</script>
+
 <style>
   /* Hero */
   .hero {
-    padding: var(--space-5xl) 0;
+    position: relative;
+    padding: var(--space-5xl) 0 var(--space-4xl);
     text-align: center;
+    overflow: hidden;
   }
 
+  .hero-glow {
+    position: absolute;
+    top: -120px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 800px;
+    height: 500px;
+    background: radial-gradient(ellipse at center, rgba(224, 122, 95, 0.12) 0%, rgba(224, 122, 95, 0.04) 40%, transparent 70%);
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .hero-pattern {
+    position: absolute;
+    inset: 0;
+    background-image: radial-gradient(circle, var(--border) 1px, transparent 1px);
+    background-size: 24px 24px;
+    opacity: 0.4;
+    pointer-events: none;
+    z-index: 0;
+    mask-image: radial-gradient(ellipse 60% 50% at 50% 40%, black 20%, transparent 70%);
+    -webkit-mask-image: radial-gradient(ellipse 60% 50% at 50% 40%, black 20%, transparent 70%);
+  }
+
+  .hero-inner { position: relative; z-index: 1; }
+
   .hero h1 {
-    font-size: var(--text-6xl);
+    font-size: var(--text-7xl);
     line-height: 1.05;
     letter-spacing: -0.04em;
     margin-bottom: var(--space-lg);
@@ -168,6 +271,7 @@ const categoryCounts = getCategoryCounts();
     color: var(--text-muted);
     max-width: 500px;
     margin: 0 auto var(--space-xl);
+    line-height: 1.6;
   }
 
   .hero-ctas {
@@ -177,84 +281,217 @@ const categoryCounts = getCategoryCounts();
     flex-wrap: wrap;
   }
 
-  /* Category Cards */
-  .card-category {
-    text-decoration: none;
+  /* Bento Grid */
+  .bento-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: var(--space-lg);
+  }
+
+  .bento-card {
+    position: relative;
     display: flex;
     flex-direction: column;
     gap: var(--space-sm);
+    padding: var(--space-xl);
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xl);
+    text-decoration: none;
+    overflow: hidden;
+    box-shadow: var(--shadow-xs);
+    transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
   }
 
-  .cat-icon {
-    font-size: var(--text-2xl);
+  .bento-card-accent {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: linear-gradient(90deg, var(--accent-primary), var(--accent-primary-muted), transparent);
+    opacity: 0;
+    transition: opacity var(--transition);
+  }
+
+  .bento-card:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-lg);
+    border-color: rgba(224, 122, 95, 0.2);
+  }
+
+  .bento-card:hover .bento-card-accent {
+    opacity: 1;
+  }
+
+  .bento-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    font-size: var(--text-xl);
+    background: var(--accent-primary-subtle);
+    border-radius: var(--radius-lg);
     margin-bottom: var(--space-xs);
   }
 
-  .cat-name {
+  .bento-name {
     font-size: var(--text-lg);
     font-weight: 600;
   }
 
-  .cat-count {
-    font-size: var(--text-xs);
-    color: var(--accent-primary);
-    font-weight: 500;
-  }
-
-  .cat-desc {
+  .bento-desc {
     font-size: var(--text-sm);
     color: var(--text-muted);
     line-height: 1.5;
   }
 
-  /* Feature Numbers */
+  /* Features Grid */
+  .features-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--space-lg);
+  }
+
+  .feature-card {
+    position: relative;
+    padding: var(--space-2xl);
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-sm);
+    transition: transform var(--transition), box-shadow var(--transition);
+  }
+
+  .feature-card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+  }
+
+  .feature-icon-wrap {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    background: var(--accent-primary-subtle);
+    border-radius: var(--radius-lg);
+    color: var(--accent-primary);
+    margin-bottom: var(--space-lg);
+  }
+
   .feature-number {
     display: block;
-    font-size: var(--text-3xl);
+    font-size: var(--text-5xl);
     font-weight: 700;
     color: var(--accent-primary);
     margin-bottom: var(--space-sm);
+    letter-spacing: -0.03em;
+    line-height: 1;
   }
 
-  .dashed-grid-item h3 {
+  .feature-card h3 {
     font-size: var(--text-lg);
     margin-bottom: var(--space-sm);
   }
 
-  .dashed-grid-item p {
+  .feature-card p {
     font-size: var(--text-sm);
     color: var(--text-muted);
+    line-height: 1.6;
   }
 
-  /* Steps */
-  .step-card {
-    text-align: center;
-    padding: var(--space-xl);
+  /* Timeline */
+  .timeline {
+    position: relative;
+    max-width: 640px;
+    margin: 0 auto;
   }
 
-  .step-number {
-    display: inline-flex;
+  .timeline-line {
+    position: absolute;
+    left: 24px;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: linear-gradient(to bottom, var(--accent-primary), var(--border));
+  }
+
+  .timeline-step {
+    position: relative;
+    display: flex;
+    gap: var(--space-xl);
+    padding-bottom: var(--space-2xl);
+  }
+
+  .timeline-step:last-child {
+    padding-bottom: 0;
+  }
+
+  .timeline-number {
+    display: flex;
     align-items: center;
     justify-content: center;
-    width: 40px;
-    height: 40px;
-    border: 1px solid var(--border);
+    flex-shrink: 0;
+    width: 50px;
+    height: 50px;
+    background: var(--gradient-coral);
+    color: #fff;
     border-radius: 50%;
-    font-size: var(--text-sm);
-    font-weight: 600;
-    color: var(--text);
-    margin-bottom: var(--space-md);
+    font-size: var(--text-lg);
+    font-weight: 700;
+    z-index: 1;
+    box-shadow: var(--shadow-md), var(--shadow-glow);
   }
 
-  .step-card h3 {
-    font-size: var(--text-lg);
+  .timeline-content {
+    padding-top: var(--space-sm);
+  }
+
+  .timeline-content h3 {
+    font-size: var(--text-xl);
     margin-bottom: var(--space-sm);
   }
 
-  .step-card p {
+  .timeline-content p {
     font-size: var(--text-sm);
     color: var(--text-muted);
-    margin: 0 auto;
+    margin: 0;
+  }
+
+  .timeline-terminal {
+    margin-top: var(--space-md);
+    background: #1a1a1a;
+    border-radius: var(--radius);
+    overflow: hidden;
+    box-shadow: var(--shadow-sm);
+  }
+
+  .timeline-terminal-header {
+    display: flex;
+    gap: 5px;
+    padding: 8px 12px;
+    background: #252525;
+  }
+
+  .timeline-terminal-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+  }
+
+  .timeline-terminal-dot:nth-child(1) { background: #FF5F57; }
+  .timeline-terminal-dot:nth-child(2) { background: #FEBC2E; }
+  .timeline-terminal-dot:nth-child(3) { background: #28C840; }
+
+  .timeline-terminal-body {
+    display: block;
+    padding: 10px 14px;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: #98C379;
+    line-height: 1.5;
   }
 
   /* API Teaser */
@@ -263,41 +500,6 @@ const categoryCounts = getCategoryCounts();
     grid-template-columns: 1fr 1fr;
     gap: var(--space-2xl);
     align-items: center;
-    background: var(--bg-elevated);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-xl);
-    padding: var(--space-2xl);
-  }
-
-  .api-code-header {
-    display: flex;
-    gap: 6px;
-    padding: var(--space-md);
-    border-bottom: 1px solid var(--border);
-  }
-
-  .api-code-dot {
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    background: var(--border-strong);
-  }
-
-  .api-teaser-code {
-    background: var(--bg-surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-lg);
-    overflow: hidden;
-  }
-
-  .api-code-body {
-    padding: var(--space-lg);
-    font-family: var(--font-mono);
-    font-size: var(--text-sm);
-    color: var(--text-secondary);
-    line-height: 1.6;
-    overflow-x: auto;
-    margin: 0;
   }
 
   .api-teaser-info h2 {
@@ -308,10 +510,57 @@ const categoryCounts = getCategoryCounts();
     margin-bottom: var(--space-lg);
   }
 
-  /* OSS Banner */
+  .api-feature-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+    margin-bottom: var(--space-xl);
+  }
+
+  .api-feature-list li {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
+    font-weight: 500;
+  }
+
+  /* OSS Section */
+  .oss-section {
+    position: relative;
+    overflow: hidden;
+  }
+
+  .oss-bg {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(ellipse 80% 60% at 50% 100%, rgba(224, 122, 95, 0.06) 0%, transparent 60%);
+    pointer-events: none;
+  }
+
   .oss-banner {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     text-align: center;
     padding: var(--space-3xl) 0;
+    z-index: 1;
+  }
+
+  .oss-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 64px;
+    height: 64px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xl);
+    color: var(--text);
+    margin-bottom: var(--space-lg);
+    box-shadow: var(--shadow-md);
   }
 
   .oss-banner h2 {
@@ -319,12 +568,25 @@ const categoryCounts = getCategoryCounts();
   }
 
   .oss-ctas {
+    display: flex;
+    gap: var(--space-md);
+    justify-content: center;
     margin-top: var(--space-xl);
+  }
+
+  @media (max-width: 1024px) {
+    .bento-grid { grid-template-columns: repeat(2, 1fr); }
   }
 
   @media (max-width: 768px) {
     .hero h1 { font-size: var(--text-4xl); }
+    .hero-glow { width: 400px; height: 300px; }
     .api-teaser { grid-template-columns: 1fr; }
     .hero-ctas { flex-direction: column; align-items: center; }
+    .bento-grid { grid-template-columns: 1fr; }
+    .features-grid { grid-template-columns: 1fr; }
+    .timeline-line { left: 20px; }
+    .timeline-number { width: 42px; height: 42px; font-size: var(--text-base); }
+    .oss-ctas { flex-direction: column; align-items: center; }
   }
 </style>

--- a/src/pages/templates.astro
+++ b/src/pages/templates.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from '@/layouts/Layout.astro';
-import { getAllTemplates, getTemplatesByCategory, getCategoryCounts } from '@/templates/registry';
+import { getAllTemplates, getCategoryCounts } from '@/templates/registry';
 import { CATEGORY_META, ALL_CATEGORIES } from '@/templates/types';
 
 const templates = getAllTemplates();
@@ -16,108 +16,252 @@ const categoryCounts = getCategoryCounts();
         <p class="section-subtitle">Browse {templates.length}+ templates. Click any template to customize and download.</p>
       </div>
 
+      <!-- Search -->
+      <div class="gallery-search-wrap">
+        <div class="gallery-search-inner">
+          <svg class="gallery-search-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+          <input type="text" class="gallery-search" id="gallery-search" placeholder="Search templates..." autocomplete="off" />
+        </div>
+      </div>
+
       <!-- Filter Bar -->
       <div class="template-filter-bar">
         <div class="pill-group">
-          <button class="pill pill-active" data-filter="all">All ({templates.length})</button>
+          <button class="pill pill-active" data-filter="all">All <span class="pill-count">{templates.length}</span></button>
           {ALL_CATEGORIES.map((cat) => {
             const meta = CATEGORY_META[cat];
             const count = categoryCounts[cat] || 0;
             return (
               <button class="pill" data-filter={cat}>
-                {meta.icon} {meta.label} ({count})
+                {meta.icon} {meta.label} <span class="pill-count">{count}</span>
               </button>
             );
           })}
         </div>
+        <div class="gallery-showing" id="gallery-showing">Showing <strong>{templates.length}</strong> of {templates.length} templates</div>
       </div>
 
       <!-- Template Grid -->
       <div class="grid grid-3 gallery-grid" id="gallery-grid">
         {templates.map((t) => (
-          <a href={`/create?template=${t.id}`} class="gallery-card" data-category={t.category}>
+          <a href={`/create?template=${t.id}`} class="gallery-card" data-category={t.category} data-name={t.name.toLowerCase()}>
             <div class="gallery-card-preview">
               <img
                 src={`/api/templates/${t.id}/thumbnail.png`}
                 alt={t.name}
+                width="600"
+                height="315"
                 loading="lazy"
-                width={600}
-                height={315}
               />
+              <div class="gallery-card-overlay">
+                <span class="gallery-card-overlay-btn">Use Template</span>
+              </div>
             </div>
             <div class="gallery-card-info">
               <span class="gallery-card-name">{t.name}</span>
-              <span class="gallery-card-cat">{CATEGORY_META[t.category].label}</span>
+              <span class="badge">{CATEGORY_META[t.category].label}</span>
             </div>
-            <span class="gallery-card-btn">Use Template</span>
           </a>
         ))}
+      </div>
+
+      <!-- Empty State -->
+      <div class="gallery-empty" id="gallery-empty" style="display: none;">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="var(--text-subtle)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/><path d="M8 11h6"/></svg>
+        <h3>No templates found</h3>
+        <p>Try a different search term or category.</p>
       </div>
     </div>
   </section>
 </Layout>
 
 <script is:inline>
-  // Category filter
+  // Category filter + search
+  const searchInput = document.getElementById('gallery-search');
+  const cards = document.querySelectorAll('.gallery-card');
+  const showingEl = document.getElementById('gallery-showing');
+  const emptyEl = document.getElementById('gallery-empty');
+  const gridEl = document.getElementById('gallery-grid');
+  const totalCount = cards.length;
+  let activeFilter = 'all';
+
+  function filterCards() {
+    const query = (searchInput?.value || '').toLowerCase().trim();
+    let visible = 0;
+
+    cards.forEach(card => {
+      const category = card.dataset.category;
+      const name = card.dataset.name || '';
+      const matchesCategory = activeFilter === 'all' || category === activeFilter;
+      const matchesSearch = !query || name.includes(query);
+
+      if (matchesCategory && matchesSearch) {
+        card.style.display = '';
+        visible++;
+      } else {
+        card.style.display = 'none';
+      }
+    });
+
+    if (showingEl) showingEl.innerHTML = 'Showing <strong>' + visible + '</strong> of ' + totalCount + ' templates';
+    if (emptyEl) emptyEl.style.display = visible === 0 ? 'flex' : 'none';
+    if (gridEl) gridEl.style.display = visible === 0 ? 'none' : '';
+  }
+
   document.querySelectorAll('[data-filter]').forEach(btn => {
     btn.addEventListener('click', () => {
-      const filter = btn.dataset.filter;
-
-      // Update active pill
+      activeFilter = btn.dataset.filter;
       document.querySelectorAll('[data-filter]').forEach(b => b.classList.remove('pill-active'));
       btn.classList.add('pill-active');
-
-      // Filter cards
-      document.querySelectorAll('.gallery-card').forEach(card => {
-        if (filter === 'all' || card.dataset.category === filter) {
-          card.style.display = '';
-        } else {
-          card.style.display = 'none';
-        }
-      });
+      filterCards();
     });
   });
+
+  searchInput?.addEventListener('input', filterCards);
 </script>
 
 <style>
+  /* Search */
+  .gallery-search-wrap {
+    max-width: 480px;
+    margin: 0 auto var(--space-xl);
+  }
+
+  .gallery-search-inner {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+
+  .gallery-search-icon {
+    position: absolute;
+    left: 16px;
+    color: var(--text-subtle);
+    pointer-events: none;
+  }
+
+  .gallery-search {
+    width: 100%;
+    padding: 14px 20px 14px 48px;
+    font-size: var(--text-base);
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xl);
+    color: var(--text);
+    box-shadow: var(--shadow-md);
+    transition: border-color var(--transition), box-shadow var(--transition);
+    outline: none;
+  }
+
+  .gallery-search::placeholder {
+    color: var(--text-subtle);
+  }
+
+  .gallery-search:focus {
+    border-color: var(--accent-primary);
+    box-shadow: var(--shadow-lg), 0 0 0 3px var(--accent-primary-subtle);
+  }
+
+  /* Filter Bar */
   .template-filter-bar {
-    margin-bottom: var(--space-2xl);
+    margin-bottom: var(--space-xl);
     overflow-x: auto;
     padding-bottom: var(--space-sm);
   }
 
+  .pill-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 20px;
+    padding: 0 5px;
+    height: 18px;
+    font-size: 10px;
+    font-weight: 600;
+    background: var(--bg-surface);
+    border-radius: var(--radius-full);
+    margin-left: 4px;
+  }
+
+  .pill-active .pill-count {
+    background: rgba(255, 255, 255, 0.2);
+    color: #fff;
+  }
+
+  .gallery-showing {
+    margin-top: var(--space-md);
+    font-size: var(--text-sm);
+    color: var(--text-subtle);
+  }
+
+  .gallery-showing strong {
+    color: var(--text);
+  }
+
+  /* Gallery Cards */
   .gallery-card {
     display: flex;
     flex-direction: column;
     background: var(--bg-elevated);
     border: 1px solid var(--border);
-    border-radius: var(--radius-lg);
+    border-radius: var(--radius-xl);
     overflow: hidden;
     text-decoration: none;
+    box-shadow: var(--shadow-xs);
     transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
   }
 
   .gallery-card:hover {
     transform: translateY(-4px);
-    box-shadow: var(--shadow-lg);
-    border-color: var(--accent-primary);
+    box-shadow: var(--shadow-lg), var(--shadow-glow);
+    border-color: rgba(224, 122, 95, 0.3);
   }
 
   .gallery-card-preview {
+    position: relative;
+    width: 100%;
     aspect-ratio: 1200 / 630;
     overflow: hidden;
     background: var(--bg-subtle);
   }
 
   .gallery-card-preview img {
+    display: block;
     width: 100%;
     height: 100%;
     object-fit: cover;
-    transition: transform var(--transition-slow);
   }
 
   .gallery-card:hover .gallery-card-preview img {
     transform: scale(1.03);
+  }
+
+  .gallery-card-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    padding-bottom: var(--space-lg);
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.5) 0%, transparent 60%);
+    opacity: 0;
+    transform: translateY(4px);
+    transition: opacity var(--transition), transform var(--transition);
+  }
+
+  .gallery-card:hover .gallery-card-overlay {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .gallery-card-overlay-btn {
+    padding: 8px 20px;
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: #fff;
+    background: var(--gradient-coral);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-md);
   }
 
   .gallery-card-info {
@@ -133,23 +277,24 @@ const categoryCounts = getCategoryCounts();
     color: var(--text);
   }
 
-  .gallery-card-cat {
-    font-size: var(--text-xs);
-    color: var(--text-subtle);
-  }
-
-  .gallery-card-btn {
-    display: block;
-    padding: var(--space-sm) var(--space-lg);
+  /* Empty State */
+  .gallery-empty {
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
     text-align: center;
-    font-size: var(--text-xs);
-    font-weight: 500;
-    color: var(--accent-primary);
-    border-top: 1px solid var(--border);
-    transition: background var(--transition);
+    padding: var(--space-4xl) var(--space-xl);
+    gap: var(--space-md);
   }
 
-  .gallery-card:hover .gallery-card-btn {
-    background: var(--accent-primary-subtle);
+  .gallery-empty h3 {
+    font-size: var(--text-lg);
+    color: var(--text-muted);
+  }
+
+  .gallery-empty p {
+    font-size: var(--text-sm);
+    color: var(--text-subtle);
+    margin: 0 auto;
   }
 </style>

--- a/src/styles/api-docs.css
+++ b/src/styles/api-docs.css
@@ -18,14 +18,18 @@
 .api-sidebar-nav {
   display: flex;
   flex-direction: column;
-  gap: var(--space-xs);
+  gap: 2px;
 }
 
 .api-sidebar-link {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
   padding: var(--space-sm) var(--space-md);
   font-size: var(--text-sm);
   color: var(--text-muted);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius);
+  border-left: 2px solid transparent;
   transition: all var(--transition);
 }
 
@@ -37,7 +41,19 @@
 .api-sidebar-link.active {
   color: var(--accent-primary);
   background: var(--accent-primary-subtle);
+  border-left-color: var(--accent-primary);
   font-weight: 500;
+}
+
+.api-sidebar-icon {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  opacity: 0.7;
+}
+
+.api-sidebar-link.active .api-sidebar-icon {
+  opacity: 1;
 }
 
 /* Content */
@@ -57,13 +73,32 @@
   max-width: 600px;
 }
 
+/* Section anchors */
+.section-anchor {
+  color: var(--text-subtle);
+  text-decoration: none;
+  opacity: 0;
+  margin-left: var(--space-sm);
+  transition: opacity var(--transition);
+}
+
+.endpoint-card:hover .section-anchor {
+  opacity: 1;
+}
+
+.section-anchor:hover {
+  color: var(--accent-primary);
+}
+
 /* Endpoint Card */
 .endpoint-card {
   background: var(--bg-elevated);
   border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-xl);
   padding: var(--space-xl);
   margin-bottom: var(--space-2xl);
+  box-shadow: var(--shadow-sm);
+  scroll-margin-top: calc(var(--nav-height) + var(--space-lg));
 }
 
 .endpoint-header {
@@ -75,13 +110,14 @@
 
 .endpoint-method {
   display: inline-flex;
-  padding: 4px 10px;
+  padding: 4px 12px;
   font-size: var(--text-xs);
   font-weight: 700;
   text-transform: uppercase;
-  border-radius: var(--radius-sm);
-  background: rgba(34, 197, 94, 0.15);
-  color: #22c55e;
+  border-radius: var(--radius);
+  background: rgba(34, 197, 94, 0.12);
+  color: #16a34a;
+  letter-spacing: 0.02em;
 }
 
 .endpoint-path {
@@ -122,6 +158,14 @@
   vertical-align: top;
 }
 
+.param-table tr:nth-child(even) td {
+  background: var(--bg-surface);
+}
+
+.param-table tr:last-child td {
+  border-bottom: none;
+}
+
 .param-name {
   font-family: var(--font-mono);
   font-size: var(--text-xs);
@@ -145,33 +189,103 @@
   color: var(--text-secondary);
 }
 
-/* Code Block */
+/* Code Block — Terminal Chrome */
 .code-block {
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
+  background: #1a1a1a;
+  border-radius: var(--radius-lg);
   overflow: hidden;
   margin-bottom: var(--space-md);
+  box-shadow: var(--shadow-md);
 }
 
 .code-block-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: var(--space-sm) var(--space-md);
-  border-bottom: 1px solid var(--border);
+  padding: 10px 16px;
+  background: #252525;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.code-block-header span {
   font-size: var(--text-xs);
-  color: var(--text-muted);
+  color: #888;
+  font-family: var(--font-mono);
+}
+
+.code-block-dots {
+  display: flex;
+  gap: 6px;
+}
+
+.code-block-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.code-block-dot:nth-child(1) { background: #FF5F57; }
+.code-block-dot:nth-child(2) { background: #FEBC2E; }
+.code-block-dot:nth-child(3) { background: #28C840; }
+
+.code-block-copy {
+  padding: 3px 10px;
+  font-size: 11px;
+  font-weight: 500;
+  color: #888;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.code-block-copy:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.15);
 }
 
 .code-block-body {
-  padding: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
   font-family: var(--font-mono);
   font-size: var(--text-xs);
-  color: var(--text-secondary);
-  line-height: 1.6;
+  color: #e0e0e0;
+  line-height: 1.7;
   overflow-x: auto;
   margin: 0;
+}
+
+/* Collapsible response */
+.code-block-collapsible {
+  overflow: hidden;
+}
+
+.code-block-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  width: 100%;
+  padding: var(--space-sm) var(--space-md);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: #888;
+  background: #1e1e1e;
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  cursor: pointer;
+  transition: color var(--transition);
+}
+
+.code-block-toggle:hover {
+  color: #ccc;
+}
+
+.code-block-toggle svg {
+  transition: transform var(--transition);
+}
+
+.code-block-toggle.expanded svg {
+  transform: rotate(180deg);
 }
 
 .code-tabs {
@@ -211,5 +325,11 @@
   }
   .api-sidebar-link {
     white-space: nowrap;
+    border-left: none;
+    border-bottom: 2px solid transparent;
+  }
+  .api-sidebar-link.active {
+    border-left-color: transparent;
+    border-bottom-color: var(--accent-primary);
   }
 }

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -18,6 +18,7 @@
   gap: var(--space-md);
   flex-shrink: 0;
   z-index: 10;
+  box-shadow: var(--shadow-xs);
 }
 
 .editor-logo {
@@ -40,6 +41,11 @@
   font-size: var(--text-sm);
   color: var(--text-muted);
   margin-right: auto;
+}
+
+.editor-topbar-sep {
+  color: var(--text-subtle);
+  font-size: var(--text-xs);
 }
 
 .editor-topbar-name {
@@ -129,11 +135,12 @@
   border-radius: var(--radius);
   color: var(--text);
   outline: none;
+  transition: border-color var(--transition), box-shadow var(--transition);
 }
 
 .template-search:focus {
   border-color: var(--accent-primary);
-  box-shadow: 0 0 0 2px var(--accent-primary-subtle);
+  box-shadow: 0 0 0 3px var(--accent-primary-subtle);
 }
 
 .template-categories {
@@ -168,6 +175,8 @@
 .template-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
+  grid-auto-rows: min-content;
+  align-content: start;
   gap: var(--space-sm);
   padding: var(--space-md);
   overflow-y: auto;
@@ -187,15 +196,17 @@
 }
 
 .template-thumb:hover { border-color: var(--border-strong); transform: translateY(-2px); box-shadow: var(--shadow-md); }
-.template-thumb.active { border-color: var(--accent-primary); box-shadow: 0 0 0 2px var(--accent-primary-subtle); }
+.template-thumb.active { border-color: var(--accent-primary); box-shadow: 0 0 0 2px var(--accent-primary-subtle), var(--shadow-glow); }
 
 .template-thumb-preview {
+  width: 100%;
   aspect-ratio: 1200 / 630;
   overflow: hidden;
   background: var(--bg-subtle);
 }
 
 .template-thumb-preview img {
+  display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -249,6 +260,10 @@
   justify-content: center;
   flex: 1;
   min-height: 300px;
+  position: relative;
+  background-image: radial-gradient(circle, var(--border-muted) 1px, transparent 1px);
+  background-size: 20px 20px;
+  border-radius: var(--radius-lg);
 }
 
 .canvas-frame {
@@ -256,7 +271,7 @@
   max-width: 800px;
   border-radius: var(--radius-lg);
   overflow: hidden;
-  box-shadow: var(--shadow-lg);
+  box-shadow: var(--shadow-xl);
 }
 
 .canvas-image {
@@ -284,6 +299,17 @@
   border-top-color: var(--accent-primary);
   border-radius: 50%;
   animation: spin 0.6s linear infinite;
+}
+
+/* Canvas loading shimmer */
+.canvas-shimmer {
+  width: 100%;
+  max-width: 800px;
+  aspect-ratio: 1200 / 630;
+  background: linear-gradient(90deg, var(--bg-surface) 0%, var(--bg-elevated) 50%, var(--bg-surface) 100%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  border-radius: var(--radius-lg);
 }
 
 /* ===== Customize Panel ===== */
@@ -334,7 +360,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--text-subtle);
+  color: var(--accent-primary);
   margin-bottom: var(--space-md);
   padding-bottom: var(--space-xs);
   border-bottom: 1px solid var(--border-muted);
@@ -367,12 +393,12 @@
   border-radius: var(--radius-sm);
   color: var(--text);
   outline: none;
-  transition: border-color var(--transition);
+  transition: border-color var(--transition), box-shadow var(--transition);
 }
 
 .editor-field-input:focus {
   border-color: var(--accent-primary);
-  box-shadow: 0 0 0 2px var(--accent-primary-subtle);
+  box-shadow: 0 0 0 3px var(--accent-primary-subtle);
 }
 
 .editor-field-textarea {
@@ -480,6 +506,7 @@
   background: var(--accent-primary);
   border-radius: 50%;
   cursor: pointer;
+  box-shadow: var(--shadow-sm);
 }
 
 /* Upload Button */
@@ -508,10 +535,19 @@
 .export-bar {
   display: flex;
   align-items: center;
+}
+
+.export-buttons {
+  display: flex;
+  align-items: center;
   gap: var(--space-sm);
 }
 
+
 .export-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   padding: 6px 14px;
   font-size: var(--text-xs);
   font-weight: 500;
@@ -523,12 +559,13 @@
 }
 
 .export-btn-primary {
-  background: var(--accent-primary);
+  background: var(--gradient-coral);
   color: white;
   border-color: var(--accent-primary);
+  box-shadow: var(--shadow-xs);
 }
 
-.export-btn-primary:hover { background: var(--accent-primary-hover); }
+.export-btn-primary:hover { box-shadow: var(--shadow-md), var(--shadow-glow); }
 .export-btn-primary:disabled { opacity: 0.6; cursor: not-allowed; }
 
 .export-btn-ghost {
@@ -556,7 +593,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--text-subtle);
+  color: var(--accent-primary);
 }
 
 .platform-strip-scroll {
@@ -572,11 +609,13 @@
 .platform-mini {
   flex-shrink: 0;
   cursor: pointer;
-  transition: transform var(--transition), width var(--transition);
+  border-radius: var(--radius);
+  transition: transform var(--transition), box-shadow var(--transition);
 }
 
 .platform-mini:hover {
-  transform: translateY(-2px);
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: var(--shadow-md);
 }
 
 .platform-mini-header {
@@ -589,6 +628,7 @@
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--text-subtle);
+  text-align: center;
 }
 
 /* ===== Viewport Switcher ===== */
@@ -657,6 +697,7 @@
   inset: 0;
   z-index: 1000;
   background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -666,7 +707,7 @@
 
 .platform-expanded-card {
   background: var(--bg-elevated);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-xl);
   box-shadow: var(--shadow-xl);
   width: 100%;
   overflow: hidden;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,7 +14,7 @@ html {
 
 body {
   min-height: 100vh;
-  line-height: 1.6;
+  line-height: 1.65;
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -41,25 +41,26 @@ ul, ol {
 /* ===== Theme Variables ===== */
 :root {
   /* Backgrounds */
-  --bg: #FAFAF9;
-  --bg-surface: #F5F5F4;
+  --bg: #FAFAFA;
+  --bg-surface: #F5F5F5;
   --bg-elevated: #FFFFFF;
-  --bg-subtle: #F0F0EE;
+  --bg-subtle: #F0F0F0;
+  --bg-frosted: rgba(255, 255, 255, 0.8);
 
   /* Borders */
-  --border: #E7E5E4;
-  --border-muted: #F0EFEE;
-  --border-strong: #D6D3D1;
+  --border: #E5E5E5;
+  --border-muted: #F0F0F0;
+  --border-strong: #D4D4D4;
 
   /* Text */
-  --text: #0C0A09;
-  --text-secondary: #292524;
-  --text-muted: #57534E;
-  --text-subtle: #A8A29E;
+  --text: #0A0A0A;
+  --text-secondary: #262626;
+  --text-muted: #525252;
+  --text-subtle: #A3A3A3;
 
   /* Accent */
-  --accent: #0C0A09;
-  --accent-muted: #292524;
+  --accent: #0A0A0A;
+  --accent-muted: #262626;
   --accent-primary: #E07A5F;
   --accent-primary-hover: #D4694F;
   --accent-primary-subtle: rgba(224, 122, 95, 0.1);
@@ -87,6 +88,7 @@ ul, ol {
   --text-4xl: 2.75rem;
   --text-5xl: 3.5rem;
   --text-6xl: 4.5rem;
+  --text-7xl: 5rem;
 
   /* Font Families */
   --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -102,14 +104,23 @@ ul, ol {
   --radius: 8px;
   --radius-lg: 12px;
   --radius-xl: 16px;
+  --radius-2xl: 20px;
   --radius-full: 9999px;
 
-  /* Shadows */
+  /* Shadows — Raycast-style multi-layer */
   --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.04);
-  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.02);
-  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.06), 0 2px 4px rgba(0, 0, 0, 0.02);
-  --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.08), 0 4px 8px rgba(0, 0, 0, 0.02);
-  --shadow-xl: 0 16px 48px rgba(0, 0, 0, 0.1), 0 8px 16px rgba(0, 0, 0, 0.04);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.02);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.05), 0 2px 4px rgba(0, 0, 0, 0.02);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.06), 0 4px 8px rgba(0, 0, 0, 0.03), 0 1px 2px rgba(0, 0, 0, 0.02);
+  --shadow-xl: 0 16px 48px rgba(0, 0, 0, 0.08), 0 8px 16px rgba(0, 0, 0, 0.04), 0 2px 4px rgba(0, 0, 0, 0.02);
+  --shadow-glow: 0 0 20px rgba(224, 122, 95, 0.15), 0 0 40px rgba(224, 122, 95, 0.08);
+  --shadow-glow-lg: 0 0 30px rgba(224, 122, 95, 0.2), 0 0 60px rgba(224, 122, 95, 0.1);
+
+  /* Gradients */
+  --gradient-hero: radial-gradient(ellipse 80% 50% at 50% -20%, rgba(224, 122, 95, 0.12), transparent);
+  --gradient-card: linear-gradient(180deg, rgba(255, 255, 255, 0.8) 0%, rgba(255, 255, 255, 0) 100%);
+  --gradient-border: linear-gradient(90deg, transparent, var(--accent-primary), transparent);
+  --gradient-coral: linear-gradient(135deg, #E07A5F 0%, #C96B52 100%);
 
   /* Transitions */
   --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
@@ -139,7 +150,7 @@ h1, h2, h3, h4, h5, h6 {
   color: var(--text);
 }
 
-h1 { font-size: var(--text-5xl); }
+h1 { font-size: var(--text-5xl); letter-spacing: -0.035em; }
 h2 { font-size: var(--text-4xl); }
 h3 { font-size: var(--text-2xl); }
 h4 { font-size: var(--text-xl); }
@@ -185,15 +196,18 @@ p {
 .btn:active { transform: translateY(0); transition-duration: var(--duration-fast); }
 
 .btn-primary {
-  background-color: var(--accent-primary);
+  background: var(--gradient-coral);
   color: #FFFFFF;
   border-color: var(--accent-primary);
+  box-shadow: var(--shadow-sm);
 }
 
 .btn-primary:hover {
-  background-color: var(--accent-primary-hover);
-  border-color: var(--accent-primary-hover);
-  box-shadow: var(--shadow-lg), 0 4px 20px var(--accent-primary-subtle);
+  box-shadow: var(--shadow-lg), var(--shadow-glow);
+}
+
+.btn-primary:active {
+  box-shadow: var(--shadow-xs);
 }
 
 .btn-secondary {
@@ -249,14 +263,16 @@ p {
 
 .section-label {
   display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
   padding: var(--space-xs) var(--space-md);
   font-size: var(--text-xs);
-  font-weight: 500;
+  font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.1em;
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
-  color: var(--text-muted);
+  color: var(--accent-primary);
   margin-bottom: var(--space-lg);
   background: var(--bg-elevated);
 }
@@ -268,6 +284,7 @@ p {
   background-color: var(--bg-elevated);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
   transition:
     transform var(--transition),
     box-shadow var(--transition),
@@ -280,12 +297,22 @@ p {
   border-color: var(--border-strong);
 }
 
+.card-interactive {
+  cursor: pointer;
+}
+
+.card-interactive:hover {
+  box-shadow: var(--shadow-lg), var(--shadow-glow);
+  border-color: rgba(224, 122, 95, 0.3);
+}
+
 /* Dashed Grid */
 .dashed-grid {
   border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-xl);
   overflow: hidden;
   background: var(--bg-elevated);
+  box-shadow: var(--shadow-sm);
 }
 
 .dashed-grid-item {
@@ -311,6 +338,26 @@ p {
   border-right: 1px solid var(--border);
 }
 
+/* ===== Badge ===== */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 10px;
+  font-size: var(--text-xs);
+  font-weight: 500;
+  border-radius: var(--radius-full);
+  background: var(--bg-surface);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+}
+
+.badge-coral {
+  background: var(--accent-primary-subtle);
+  color: var(--accent-primary);
+  border-color: rgba(224, 122, 95, 0.2);
+}
+
 /* ===== Pills ===== */
 .pill {
   display: inline-flex;
@@ -322,11 +369,22 @@ p {
   border-radius: var(--radius-full);
   color: var(--text-muted);
   background-color: var(--bg-elevated);
-  transition: border-color var(--transition), color var(--transition);
+  box-shadow: var(--shadow-xs);
+  transition: border-color var(--transition), color var(--transition), background var(--transition), box-shadow var(--transition);
 }
 
-.pill:hover { border-color: var(--text-subtle); color: var(--text); }
-.pill-active { background-color: var(--text); color: var(--bg); border-color: var(--text); }
+.pill:hover {
+  border-color: var(--text-subtle);
+  color: var(--text);
+  background-color: var(--bg-surface);
+}
+
+.pill-active {
+  background: var(--gradient-coral);
+  color: #FFFFFF;
+  border-color: var(--accent-primary);
+  box-shadow: var(--shadow-sm);
+}
 
 .pill-group { display: flex; flex-wrap: wrap; gap: var(--space-sm); }
 
@@ -370,20 +428,123 @@ p {
 /* ===== Dividers ===== */
 .divider { width: 100%; height: 1px; background: var(--border); }
 
+/* ===== Gradient Border (reusable) ===== */
+.gradient-border-top {
+  position: relative;
+}
+
+.gradient-border-top::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--gradient-border);
+}
+
+.gradient-border-bottom {
+  position: relative;
+}
+
+.gradient-border-bottom::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--gradient-border);
+}
+
+/* ===== Terminal Chrome ===== */
+.terminal {
+  background: #1a1a1a;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-lg);
+}
+
+.terminal-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  background: #252525;
+}
+
+.terminal-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.terminal-dot:nth-child(1) { background: #FF5F57; }
+.terminal-dot:nth-child(2) { background: #FEBC2E; }
+.terminal-dot:nth-child(3) { background: #28C840; }
+
+.terminal-title {
+  flex: 1;
+  text-align: center;
+  font-size: var(--text-xs);
+  color: #888;
+  font-family: var(--font-mono);
+}
+
+.terminal-actions {
+  display: flex;
+  gap: var(--space-sm);
+}
+
+.terminal-copy-btn {
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 500;
+  color: #888;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.terminal-copy-btn:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.terminal-body {
+  padding: var(--space-lg) var(--space-xl);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: 1.7;
+  color: #e0e0e0;
+  overflow-x: auto;
+}
+
+.terminal-body code {
+  color: inherit;
+}
+
+.terminal-body .token-string { color: #98C379; }
+.terminal-body .token-keyword { color: #C678DD; }
+.terminal-body .token-comment { color: #5C6370; }
+.terminal-body .token-param { color: #61AFEF; }
+
 /* ===== Animations ===== */
 [data-animate] {
   opacity: 0;
-  transform: translateY(20px);
+  transform: translateY(12px);
   transition:
     opacity var(--duration-slower) var(--ease-out),
     transform var(--duration-slower) var(--ease-out);
 }
 
 [data-animate].is-visible { opacity: 1; transform: translateY(0); }
-[data-animate-delay="1"] { transition-delay: 50ms; }
-[data-animate-delay="2"] { transition-delay: 100ms; }
-[data-animate-delay="3"] { transition-delay: 150ms; }
-[data-animate-delay="4"] { transition-delay: 200ms; }
+[data-animate-delay="1"] { transition-delay: 80ms; }
+[data-animate-delay="2"] { transition-delay: 160ms; }
+[data-animate-delay="3"] { transition-delay: 240ms; }
+[data-animate-delay="4"] { transition-delay: 320ms; }
 
 @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
 @keyframes slideUp { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
@@ -391,6 +552,16 @@ p {
 @keyframes shimmer {
   0% { background-position: -200% 0; }
   100% { background-position: 200% 0; }
+}
+
+@keyframes float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-6px); }
+}
+
+@keyframes pulse-glow {
+  0%, 100% { box-shadow: var(--shadow-sm), 0 0 0 rgba(224, 122, 95, 0); }
+  50% { box-shadow: var(--shadow-md), var(--shadow-glow); }
 }
 
 .skeleton {
@@ -428,9 +599,17 @@ p {
 .mb-lg { margin-bottom: var(--space-lg); }
 .mb-xl { margin-bottom: var(--space-xl); }
 
+/* Gradient text utility */
+.text-gradient {
+  background: var(--gradient-coral);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
 ::selection {
-  background-color: var(--text);
-  color: var(--bg);
+  background-color: var(--accent-primary);
+  color: #fff;
 }
 
 ::-webkit-scrollbar { width: 6px; height: 6px; }
@@ -438,7 +617,7 @@ p {
 ::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: var(--radius-full); }
 ::-webkit-scrollbar-thumb:hover { background: var(--text-subtle); }
 
-:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
+:focus-visible { outline: 2px solid var(--accent-primary); outline-offset: 2px; }
 
 /* ===== Responsive ===== */
 @media (max-width: 1024px) {


### PR DESCRIPTION
## Summary
- Full visual overhaul across all pages inspired by Raycast's design language — crisp typography, generous whitespace, subtle gradients, soft glows, and micro-interactions
- Enhanced design system foundation: layered shadows, glassmorphism, gradient variables, animation utilities, terminal chrome component
- Redesigned homepage, templates gallery, editor, API docs, 404 page, header, and footer
- Fixed thumbnail API cropping bug: templates now render at full 1200x630 and scale down via resvg
- Added Astro View Transitions for smooth page navigation
- Added GitHub stars, visitor counter utilities, and .env.example

## Test plan
- [x] `npm run build` passes with zero errors
- [x] `npm run check` and `npm run test` pass
- [x] Visual check on desktop, tablet, and mobile
- [x] Template thumbnails show full design on `/templates` and editor sidebar
- [x] All existing functionality works: template selection, editor, export, preview checker, API