### PR TITLE
fix: visitor counter 403 on Vercel

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -194,7 +194,7 @@ const year = new Date().getFullYear();
   function loadVisitors() {
     // One increment per session
     if (!sessionStorage.getItem('ogcops-counted')) {
-      fetch('/api/visitors', { method: 'POST' })
+      fetch('/api/visitors', { method: 'POST', headers: { 'Content-Type': 'application/json' } })
         .then(function(r) { return r.json(); })
         .then(function(data) {
           sessionStorage.setItem('ogcops-counted', '1');


### PR DESCRIPTION
## Summary
- Add `Content-Type: application/json` header to the visitor counter POST request in the footer
- Vercel's CSRF protection blocks POST requests without this header, returning 403 Forbidden with "Cross-site POST form submissions are forbidden"

## Root cause
Vercel blocks POST requests with form-like content types (`application/x-www-form-urlencoded`, `multipart/form-data`, `text/plain`). A `fetch()` with `method: 'POST'` and no explicit `Content-Type` defaults to `text/plain`, which triggers the block.

## Test plan
- [x] Deploy to Vercel and verify `/api/visitors` POST returns 200 with JSON
- [x] No more `403 Forbidden` or JSON parse errors in browser console
- [x] Visitor counts update correctly in the footer