### PR TITLE
chore: rename main branch references to production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, dev]
+    branches: [production, dev]
   pull_request:
-    branches: [main, dev]
+    branches: [production, dev]
 
 jobs:
   build:

--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -2,16 +2,16 @@ name: PR Target Check
 
 on:
   pull_request:
-    branches: [main]
+    branches: [production]
 
 jobs:
   check-source-branch:
     runs-on: ubuntu-latest
     steps:
-      - name: Only allow PRs from dev to main
+      - name: Only allow PRs from dev to production
         if: github.head_ref != 'dev'
         run: |
-          echo "::error::PRs targeting 'main' are only allowed from the 'dev' branch."
+          echo "::error::PRs targeting 'production' are only allowed from the 'dev' branch."
           echo "Please target 'dev' instead, or merge your branch into 'dev' first."
           echo ""
           echo "  Source: ${{ github.head_ref }}"
@@ -19,4 +19,4 @@ jobs:
           exit 1
       - name: PR source branch is valid
         if: github.head_ref == 'dev'
-        run: echo "PR from 'dev' to 'main' — allowed."
+        run: echo "PR from 'dev' to 'production' — allowed."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ npm run build        # Full production build
 1. Fork the repo and create a branch: `git checkout -b feat/my-feature`
 2. Make your changes
 3. Ensure `npm run check` and `npm run test` pass
-4. Push and open a PR against `main`
+4. Push and open a PR against `dev`
 5. Fill out the [PR template](.github/PULL_REQUEST_TEMPLATE.md) — screenshots are required for visual changes
 6. Wait for review
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ OGCOPS is different:
 ## Quick Start
 
 ```bash
-git clone https://github.com/codercops/ogcops.git
+git clone -b dev https://github.com/codercops/ogcops.git
 cd ogcops
 npm install
 npm run dev
@@ -113,6 +113,16 @@ The build output in `dist/` can be deployed to any Node.js hosting platform.
 ## Contributing
 
 Contributions are welcome — templates, bug fixes, features, docs, and more. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup and guidelines.
+
+> **Important:** Always fork and branch from `dev` (the default branch). The `production` branch is for releases only. PRs targeting `production` directly will be closed.
+
+```bash
+# Fork the repo on GitHub, then:
+git clone https://github.com/<your-username>/ogcops.git
+cd ogcops
+git checkout dev
+git checkout -b your-feature-branch
+```
 
 - [Open an issue](https://github.com/codercops/ogcops/issues) — bug reports and feature requests
 - [Start a discussion](https://github.com/codercops/ogcops/discussions) — questions, ideas, show & tell

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,7 @@ The following are **out of scope:**
 
 | Version | Supported |
 |---------|-----------|
-| Latest (main branch) | Yes |
+| Latest (production branch) | Yes |
 | Older releases | No |
 
 ## Recognition


### PR DESCRIPTION
## Summary
- Update all references from `main` to `production` across CI workflows, README, CONTRIBUTING, and SECURITY
- CI now triggers on `production` and `dev` branches
- PR target check enforces `dev → production` flow
- Contributing docs direct PRs to `dev`

## Files changed
- `.github/workflows/ci.yml` — branch triggers
- `.github/workflows/pr-target-check.yml` — branch guard
- `README.md` — contributing instructions
- `CONTRIBUTING.md` — PR target branch
- `SECURITY.md` — supported version reference