### PR TITLE
release: v1.2.0 — Hero redesign & support buttons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, dev]
+    branches: [production, dev]
   pull_request:
-    branches: [main, dev]
+    branches: [production, dev]
 
 jobs:
   build:

--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -2,16 +2,16 @@ name: PR Target Check
 
 on:
   pull_request:
-    branches: [main]
+    branches: [production]
 
 jobs:
   check-source-branch:
     runs-on: ubuntu-latest
     steps:
-      - name: Only allow PRs from dev to main
+      - name: Only allow PRs from dev to production
         if: github.head_ref != 'dev'
         run: |
-          echo "::error::PRs targeting 'main' are only allowed from the 'dev' branch."
+          echo "::error::PRs targeting 'production' are only allowed from the 'dev' branch."
           echo "Please target 'dev' instead, or merge your branch into 'dev' first."
           echo ""
           echo "  Source: ${{ github.head_ref }}"
@@ -19,4 +19,4 @@ jobs:
           exit 1
       - name: PR source branch is valid
         if: github.head_ref == 'dev'
-        run: echo "PR from 'dev' to 'main' — allowed."
+        run: echo "PR from 'dev' to 'production' — allowed."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,16 +1,21 @@
 # CLAUDE.md — OGCOPS
 
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 ## What is this?
-OGCOPS is a free, open-source OG image generator and social media preview checker. Built with Astro + React Islands, deployed to Vercel.
+OGCOPS is a free, open-source OG image generator and social media preview checker. Built with Astro SSR + React Islands, deployed to Vercel at og.codercops.com. GitHub: github.com/codercops/ogcops. MIT licensed.
 
 ## Commands
 ```bash
-npm run dev          # Start dev server
-npm run build        # Production build
-npm run preview      # Preview production build
-npm run test         # Run vitest
-npm run test:watch   # Watch mode
-npm run check        # Type-check (astro check + tsc)
+npm run dev              # Start dev server (port 4321)
+npm run build            # Production build
+npm run preview          # Preview production build
+npm run test             # Run vitest (single run)
+npm run test:watch       # Watch mode
+npm run test:ui          # Vitest UI
+npm run check            # Type-check (astro check + tsc --noEmit)
+npm run lint             # Astro linting
+npm run generate:favicons  # Generate favicon assets
 ```
 
 ## Architecture
@@ -19,20 +24,32 @@ npm run check        # Type-check (astro check + tsc)
 - **Satori** runs client-side for instant SVG preview (zero server calls during editing)
 - **Satori + resvg-wasm** runs server-side for PNG generation (`/api/og`)
 - **No database** — state lives in URL query params + client-side useReducer
-- **CORS-open API** for developer use
+- **CORS-open API** — no API key, no rate limits
 
 ## Key Directories
-- `src/templates/` — 109 templates across 12 categories. Each template is a `.ts` file exporting a `TemplateDefinition`.
-- `src/lib/` — Core engine (og-engine.ts, font-loader.ts, meta-fetcher.ts, meta-analyzer.ts)
+- `src/templates/` — 120 templates across 12 categories. Each is a `.ts` file exporting a `TemplateDefinition`.
+- `src/lib/` — Core engine (og-engine.ts, font-loader.ts, meta-fetcher.ts, meta-analyzer.ts, api-validation.ts)
 - `src/components/editor/` — React components for the OG image editor
 - `src/components/preview/` — React components for the social media preview checker
-- `src/pages/api/` — API endpoints (og, preview, templates)
+- `src/pages/api/` — API endpoints
+- `src/styles/` — CSS files (global.css, editor.css, preview.css, api-docs.css)
+- `public/fonts/` — Bundled .woff fonts (Inter, Playfair Display, JetBrains Mono)
+- `tests/` — Vitest tests (api/, lib/, templates/)
 
-## Conventions
-- CSS custom properties only (no Tailwind). Accent: `#E07A5F`.
-- TypeScript strict mode. Path alias `@/*` → `src/*`.
-- Fonts bundled as `.woff` in `public/fonts/`.
-- Templates follow `TemplateDefinition` interface in `src/templates/types.ts`.
+## Pages & API Endpoints
+
+**Pages:**
+- `/` — Homepage
+- `/create/` — OG image editor
+- `/templates` — Template gallery
+- `/preview` — Social media preview checker
+- `/api-docs` — API documentation
+
+**API (all CORS-open, no auth):**
+- `GET /api/og?template={id}&...` — Generate PNG (1200x630, 24h cache)
+- `GET /api/preview?url={url}` — Fetch and analyze a URL's meta tags
+- `GET /api/templates` — List all templates as JSON
+- `GET /api/templates/[id]/thumbnail.png` — Template thumbnail (1-week cache)
 
 ## Reference Files
 - Template interface: `src/templates/types.ts`
@@ -42,11 +59,33 @@ npm run check        # Type-check (astro check + tsc)
 - API validation schemas: `src/lib/api-validation.ts`
 - Template registry: `src/templates/registry.ts`
 
-## Template Contribution
-1. Create `src/templates/{category}/{id}.ts`
-2. Export a `TemplateDefinition`
-3. Register in `src/templates/{category}/index.ts`
+## Template System
+
+120 templates across 12 categories: blog, product, saas, github, event, podcast, developer, newsletter, quote, ecommerce, job, tutorial.
+
+**Adding a template:**
+1. Create `src/templates/{category}/{id}.ts` exporting a `TemplateDefinition`
+2. Register in `src/templates/{category}/index.ts`
+3. Add import + registration in `src/templates/registry.ts`
 4. Run `npm run test` to verify
+
+**Template field types:** text, textarea, color, select, number, toggle, image.
+**Field groups:** Content, Style, Brand.
+
+## Conventions
+- CSS custom properties only (no Tailwind). Accent: `#E07A5F`.
+- TypeScript strict mode. Path alias `@/*` → `src/*`.
+- Fonts bundled as `.woff` in `public/fonts/` (Inter Regular/Medium/SemiBold/Bold, Playfair Display Regular/Bold, JetBrains Mono Regular/Bold).
+- Node 22 (`.nvmrc`).
+- Testing: Vitest with node environment. Tests in `tests/**/*.test.ts`. Globals enabled.
+
+## CI/CD
+- Runs on push to `production`/`dev` and PRs to those branches
+- Steps: `npm run check` → `npm run test` → `npm run build`
+- **Branch strategy:** `dev` is the default branch. PRs target `dev`. Releases go `dev` → `production`. Direct PRs to `production` are blocked unless from `dev`.
+
+## Environment Variables (`.env.local`, all optional)
+- `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN` — Optional visitor counter
 
 ## Gotchas / Constraints
 - Satori does **not** support CSS grid — only flexbox
@@ -55,6 +94,7 @@ npm run check        # Type-check (astro check + tsc)
 - Font files must be listed in `astro.config.mjs` `includeFiles` array for Vercel deployment
 - WASM imports need `optimizeDeps.exclude` in the Vite config
 - `renderToPng` returns `ArrayBuffer` (not `Buffer`) for `BodyInit` compatibility
+- Canvas is always 1200x630px
 
 ## Do NOT
 - Add Tailwind CSS — the project uses CSS custom properties only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ npm run build        # Full production build
 1. Fork the repo and create a branch: `git checkout -b feat/my-feature`
 2. Make your changes
 3. Ensure `npm run check` and `npm run test` pass
-4. Push and open a PR against `main`
+4. Push and open a PR against `dev`
 5. Fill out the [PR template](.github/PULL_REQUEST_TEMPLATE.md) — screenshots are required for visual changes
 6. Wait for review
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ OGCOPS is different:
 ## Quick Start
 
 ```bash
-git clone https://github.com/codercops/ogcops.git
+git clone -b dev https://github.com/codercops/ogcops.git
 cd ogcops
 npm install
 npm run dev
@@ -113,6 +113,16 @@ The build output in `dist/` can be deployed to any Node.js hosting platform.
 ## Contributing
 
 Contributions are welcome — templates, bug fixes, features, docs, and more. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup and guidelines.
+
+> **Important:** Always fork and branch from `dev` (the default branch). The `production` branch is for releases only. PRs targeting `production` directly will be closed.
+
+```bash
+# Fork the repo on GitHub, then:
+git clone https://github.com/<your-username>/ogcops.git
+cd ogcops
+git checkout dev
+git checkout -b your-feature-branch
+```
 
 - [Open an issue](https://github.com/codercops/ogcops/issues) — bug reports and feature requests
 - [Start a discussion](https://github.com/codercops/ogcops/discussions) — questions, ideas, show & tell

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,7 @@ The following are **out of scope:**
 
 | Version | Supported |
 |---------|-----------|
-| Latest (main branch) | Yes |
+| Latest (production branch) | Yes |
 | Older releases | No |
 
 ## Recognition

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -20,6 +20,7 @@ const year = new Date().getFullYear();
         <a href="/templates">Templates</a>
         <a href="/api-docs">API Docs</a>
         <a href="https://github.com/codercops/ogcops" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/codercops/ogcops/issues/new?labels=feedback&title=Feedback:&body=<!-- Describe your feedback here -->" target="_blank" rel="noopener">Feedback</a>
       </nav>
     </div>
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -36,41 +36,82 @@ const navItems = [
       </a>
     </div>
 
-    <button class="mobile-menu-btn" id="mobile-menu-btn" aria-label="Menu">
+    <button class="mobile-menu-btn" id="mobile-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">
       <span></span><span></span><span></span>
     </button>
   </nav>
+
+  <!-- Mobile menu lives inside <header> so it survives transition:persist -->
+  <div class="mobile-menu" id="mobile-menu">
+    <div class="mobile-menu-inner">
+      {navItems.map((item, i) => (
+        <a
+          href={item.href}
+          class:list={['mobile-menu-link', { 'mobile-link-active': currentPath === item.href || (item.href !== '/' && currentPath.startsWith(item.href)) }]}
+          style={`--delay: ${i * 50}ms`}
+        >
+          {item.label}
+        </a>
+      ))}
+      <a href="https://github.com/codercops/ogcops" target="_blank" rel="noopener" class="mobile-menu-link mobile-github-link" style={`--delay: ${navItems.length * 50}ms`}>
+        <svg class="github-icon" viewBox="0 0 16 16" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>
+        Star on GitHub
+        {starCount !== null && <span class="star-count">{formatStarCount(starCount)}</span>}
+      </a>
+    </div>
+  </div>
 </header>
 
-<!-- Mobile Menu -->
-<div class="mobile-menu" id="mobile-menu">
-  <div class="mobile-menu-inner">
-    {navItems.map((item, i) => (
-      <a href={item.href} class="mobile-menu-link" style={`--delay: ${i * 50}ms`}>{item.label}</a>
-    ))}
-    <a href="https://github.com/codercops/ogcops" target="_blank" rel="noopener" class="mobile-menu-link mobile-github-link" style={`--delay: ${navItems.length * 50}ms`}>
-      <svg class="github-icon" viewBox="0 0 16 16" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>
-      Star on GitHub
-      {starCount !== null && <span class="star-count">{formatStarCount(starCount)}</span>}
-    </a>
-  </div>
-</div>
-
 <script is:inline>
-  // Mobile menu
-  const menuBtn = document.getElementById('mobile-menu-btn');
-  const mobileMenu = document.getElementById('mobile-menu');
-  menuBtn?.addEventListener('click', () => {
-    menuBtn.classList.toggle('open');
-    mobileMenu?.classList.toggle('open');
-  });
+  (function() {
+    var menuBtn = document.getElementById('mobile-menu-btn');
+    var menu = document.getElementById('mobile-menu');
+    if (!menuBtn || !menu) return;
+
+    function openMenu() {
+      menuBtn.classList.add('open');
+      menuBtn.setAttribute('aria-expanded', 'true');
+      menu.classList.add('open');
+      document.body.style.overflow = 'hidden';
+    }
+
+    function closeMenu() {
+      menuBtn.classList.remove('open');
+      menuBtn.setAttribute('aria-expanded', 'false');
+      menu.classList.remove('open');
+      document.body.style.overflow = '';
+    }
+
+    menuBtn.addEventListener('click', function() {
+      if (menu.classList.contains('open')) {
+        closeMenu();
+      } else {
+        openMenu();
+      }
+    });
+
+    menu.addEventListener('click', function(e) {
+      if (e.target.closest('.mobile-menu-link')) {
+        closeMenu();
+      } else if (e.target === menu || !e.target.closest('.mobile-menu-inner')) {
+        closeMenu();
+      }
+    });
+
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape' && menu.classList.contains('open')) {
+        closeMenu();
+      }
+    });
+  })();
 </script>
 
 <style>
+  /* ===== Header bar ===== */
   .header {
     position: sticky;
     top: 0;
-    z-index: 100;
+    z-index: 500;
     background: var(--bg-frosted);
     backdrop-filter: saturate(180%) blur(20px);
     -webkit-backdrop-filter: saturate(180%) blur(20px);
@@ -108,7 +149,6 @@ const navItems = [
   }
 
   .logo-fallback { display: none; }
-
   .logo-text { color: var(--text); }
   .logo-accent { color: var(--accent-primary); }
 
@@ -127,6 +167,7 @@ const navItems = [
     line-height: 1.4;
   }
 
+  /* ===== Desktop links ===== */
   .header-links {
     display: flex;
     align-items: center;
@@ -183,18 +224,32 @@ const navItems = [
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
   }
 
+  /* ===== Hamburger button ===== */
   .mobile-menu-btn {
     display: none;
     flex-direction: column;
-    gap: 4px;
-    width: 36px;
-    height: 36px;
+    gap: 5px;
+    width: 44px;
+    height: 44px;
     align-items: center;
     justify-content: center;
     border: none;
     background: none;
     cursor: pointer;
-    padding: 8px;
+    padding: 0;
+    margin-left: auto;
+    -webkit-tap-highlight-color: transparent;
+    border-radius: var(--radius);
+    transition: background-color var(--transition);
+    flex-shrink: 0;
+    position: relative;
+    z-index: 210;
+    touch-action: manipulation;
+  }
+
+  .mobile-menu-btn:hover,
+  .mobile-menu-btn:active {
+    background-color: var(--bg-surface);
   }
 
   .mobile-menu-btn span {
@@ -202,42 +257,109 @@ const navItems = [
     width: 20px;
     height: 2px;
     background: var(--text);
-    transition: transform var(--transition), opacity var(--transition);
+    border-radius: 1px;
+    transform-origin: center;
+    transition: transform 0.3s var(--ease-out), opacity 0.2s var(--ease-out);
   }
 
-  .mobile-menu-btn.open span:nth-child(1) { transform: rotate(45deg) translate(4px, 4px); }
-  .mobile-menu-btn.open span:nth-child(2) { opacity: 0; }
-  .mobile-menu-btn.open span:nth-child(3) { transform: rotate(-45deg) translate(4px, -4px); }
-
-  .mobile-menu {
-    display: none;
-    position: fixed;
-    inset: var(--nav-height) 0 0 0;
-    background: var(--bg-frosted);
-    backdrop-filter: saturate(180%) blur(20px);
-    -webkit-backdrop-filter: saturate(180%) blur(20px);
-    z-index: 99;
-    padding: var(--space-xl);
+  .mobile-menu-btn.open span:nth-child(1) {
+    transform: translateY(7px) rotate(45deg);
+  }
+  .mobile-menu-btn.open span:nth-child(2) {
     opacity: 0;
-    transform: translateY(-8px);
-    transition: opacity var(--transition), transform var(--transition);
+    transform: scaleX(0);
+  }
+  .mobile-menu-btn.open span:nth-child(3) {
+    transform: translateY(-7px) rotate(-45deg);
+  }
+
+  /* ===== Mobile menu overlay ===== */
+  .mobile-menu {
+    position: fixed;
+    left: 0;
+    right: 0;
+    top: var(--nav-height);
+    bottom: 0;
+    z-index: 200;
+    visibility: hidden;
+    pointer-events: none;
   }
 
   .mobile-menu.open {
-    opacity: 1;
-    transform: translateY(0);
+    visibility: visible;
+    pointer-events: auto;
   }
 
+  /* Backdrop dim */
+  .mobile-menu::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.2);
+    opacity: 0;
+    transition: opacity 0.3s var(--ease-out);
+  }
+
+  .mobile-menu.open::before {
+    opacity: 1;
+  }
+
+  .mobile-menu-inner {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-frosted);
+    backdrop-filter: saturate(180%) blur(24px);
+    -webkit-backdrop-filter: saturate(180%) blur(24px);
+    border-bottom: 1px solid var(--border);
+    box-shadow: var(--shadow-lg);
+    padding: var(--space-sm) var(--space-xl);
+    padding-bottom: max(var(--space-lg), env(safe-area-inset-bottom));
+    max-height: calc(100vh - var(--nav-height));
+    max-height: calc(100dvh - var(--nav-height));
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    transform: translateY(-12px);
+    opacity: 0;
+    transition: transform 0.3s var(--ease-out), opacity 0.25s var(--ease-out);
+  }
+
+  .mobile-menu.open .mobile-menu-inner {
+    transform: translateY(0);
+    opacity: 1;
+  }
+
+  /* ===== Mobile menu links ===== */
   .mobile-menu-link {
-    display: block;
-    padding: var(--space-md) 0;
-    font-size: var(--text-lg);
+    display: flex;
+    align-items: center;
+    padding: var(--space-lg) var(--space-sm);
+    font-size: var(--text-base);
     font-weight: 500;
     color: var(--text);
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid var(--border-muted);
+    min-height: 52px;
+    -webkit-tap-highlight-color: transparent;
+    border-radius: var(--radius);
+    transition: background-color 0.15s ease, color 0.15s ease;
     opacity: 0;
-    transform: translateY(-4px);
-    transition: opacity 0.3s ease var(--delay, 0ms), transform 0.3s ease var(--delay, 0ms);
+    transform: translateY(-6px);
+    transition: opacity 0.3s ease var(--delay, 0ms),
+                transform 0.3s ease var(--delay, 0ms),
+                background-color 0.15s ease;
+  }
+
+  .mobile-menu-link:last-child {
+    border-bottom: none;
+  }
+
+  .mobile-menu-link:active {
+    background-color: var(--bg-surface);
+  }
+
+  .mobile-menu-link.mobile-link-active {
+    color: var(--accent-primary);
+    font-weight: 600;
   }
 
   .mobile-menu.open .mobile-menu-link {
@@ -249,21 +371,64 @@ const navItems = [
     display: flex;
     align-items: center;
     gap: var(--space-sm);
+    margin-top: var(--space-xs);
+    padding-top: var(--space-lg);
+    border-top: 1px solid var(--border);
+    border-bottom: none;
   }
 
   .mobile-github-link .star-count {
     margin-left: auto;
-    padding: 2px 8px;
+    padding: 3px 10px;
     background: var(--bg-surface);
     border: 1px solid var(--border);
     border-radius: var(--radius-sm);
     font-size: var(--text-xs);
   }
 
+  /* ===== Mobile breakpoints ===== */
   @media (max-width: 768px) {
     .header-links { display: none; }
     .mobile-menu-btn { display: flex; }
-    .mobile-menu { display: block; }
     .oss-badge { display: none; }
+
+    .header-nav {
+      height: var(--nav-height);
+      padding: 0 var(--space-md);
+      gap: var(--space-md);
+    }
+
+    .mobile-menu {
+      top: var(--nav-height);
+    }
+
+    .logo-img {
+      height: 24px;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .header-nav {
+      height: var(--nav-height);
+      padding: 0 var(--space-sm);
+    }
+
+    .mobile-menu-inner {
+      padding-left: var(--space-md);
+      padding-right: var(--space-md);
+    }
+
+    .logo-img {
+      height: 22px;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .mobile-menu-inner,
+    .mobile-menu-link,
+    .mobile-menu-btn span,
+    .mobile-menu::before {
+      transition-duration: 0.01ms !important;
+    }
   }
 </style>

--- a/src/components/editor/EditorApp.tsx
+++ b/src/components/editor/EditorApp.tsx
@@ -31,6 +31,17 @@ export function EditorApp({ initialCategory }: EditorAppProps) {
 
   const { svg, loading, error, render } = useSatoriRenderer();
   const [mobileTab, setMobileTab] = useState<'templates' | 'customize' | 'export'>('customize');
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth <= 768 : false
+  );
+
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 768px)');
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener('change', handler);
+    setIsMobile(mq.matches);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
 
   // Find current template definition (use registry lookup to ensure render function is present)
   const currentTemplate = useMemo(
@@ -59,8 +70,11 @@ export function EditorApp({ initialCategory }: EditorAppProps) {
   const handleTemplateSelect = useCallback(
     (template: TemplateDefinition) => {
       setTemplate(template);
+      if (isMobile) {
+        setMobileTab('customize');
+      }
     },
-    [setTemplate]
+    [setTemplate, isMobile]
   );
 
   const handleReset = useCallback(() => {
@@ -114,11 +128,20 @@ export function EditorApp({ initialCategory }: EditorAppProps) {
           />
         </div>
 
-        {/* Right: Customize */}
+        {/* Right: Customize / Export */}
         <div className={`editor-right ${mobileTab === 'customize' || mobileTab === 'export' ? 'mobile-show' : 'mobile-hide'}`}>
           {mobileTab === 'export' ? (
             <div className="editor-export-mobile">
+              <div className="editor-export-preview">
+                <Canvas svg={svg} loading={loading} error={error} />
+              </div>
               <ExportBar apiUrl={apiUrl} downloadUrl={downloadUrl} params={state.params} templateId={state.templateId} />
+              <PlatformPreviewStrip
+                svg={svg}
+                title={String(state.params.title || '')}
+                description={String(state.params.description || '')}
+                siteName={String(state.params.siteName || '')}
+              />
             </div>
           ) : (
             <CustomizePanel

--- a/src/components/editor/ExportBar.tsx
+++ b/src/components/editor/ExportBar.tsx
@@ -117,13 +117,15 @@ export function ExportBar({ apiUrl, downloadUrl, params, templateId }: ExportBar
           className="export-btn export-btn-ghost"
           onClick={() => copyToClipboard(apiUrl, 'url')}
         >
-          {copied === 'url' ? 'Copied!' : 'Copy URL'}
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+          {copied === 'url' ? 'Copied!' : 'Copy Image URL'}
         </button>
         <button
           type="button"
           className="export-btn export-btn-ghost"
           onClick={() => copyToClipboard(metaTags, 'meta')}
         >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
           {copied === 'meta' ? 'Copied!' : 'Copy Meta Tags'}
         </button>
       </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -31,7 +31,7 @@ const fullTitle = title === 'OGCOPS' ? title : `${title} | ${siteName}`;
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content={description} />
     {noindex && <meta name="robots" content="noindex, nofollow" />}
     <link rel="canonical" href={canonicalURL} />
@@ -106,7 +106,7 @@ const fullTitle = title === 'OGCOPS' ? title : `${title} | ${siteName}`;
     <slot name="head" />
   </head>
   <body>
-    <Header transition:persist />
+    <Header />
     <main transition:animate="fade">
       <slot />
     </main>

--- a/src/layouts/ToolLayout.astro
+++ b/src/layouts/ToolLayout.astro
@@ -19,7 +19,7 @@ const fullTitle = `${title} | ${siteName}`;
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content={description} />
 
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
@@ -61,7 +61,14 @@ const fullTitle = `${title} | ${siteName}`;
   body {
     display: flex;
     flex-direction: column;
+    min-height: 100vh;
+    min-height: 100dvh;
     height: 100vh;
+    height: 100dvh;
     overflow: hidden;
+    padding-top: env(safe-area-inset-top);
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+    padding-bottom: env(safe-area-inset-bottom);
   }
 </style>

--- a/src/pages/api-docs.astro
+++ b/src/pages/api-docs.astro
@@ -5,24 +5,29 @@ import '@/styles/api-docs.css';
 
 <Layout title="API Documentation" description="Free REST API to generate OG images, check meta tags, and list templates. No API key required.">
   <div class="api-docs">
-    <!-- Sidebar -->
+    <!-- Hero: always above the sticky bar on mobile -->
+    <div class="api-hero" id="overview">
+      <h1>API Documentation</h1>
+      <p class="api-intro">
+        Generate OG images, check URL meta tags, and list templates with our free REST API.
+        No API key required. CORS-enabled for browser use.
+      </p>
+    </div>
+
+    <!-- Sticky section nav -->
     <aside class="api-sidebar">
       <nav class="api-sidebar-nav">
-        <a href="#overview" class="api-sidebar-link active">
-          <svg class="api-sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
-          Overview
-        </a>
-        <a href="#generate" class="api-sidebar-link">
+        <a href="#generate" class="api-sidebar-link active">
           <svg class="api-sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>
-          Generate Image
+          Generate
         </a>
         <a href="#preview" class="api-sidebar-link">
           <svg class="api-sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
-          Preview URL
+          Preview
         </a>
         <a href="#templates" class="api-sidebar-link">
           <svg class="api-sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="7" height="7" x="3" y="3" rx="1"/><rect width="7" height="7" x="14" y="3" rx="1"/><rect width="7" height="7" x="14" y="14" rx="1"/><rect width="7" height="7" x="3" y="14" rx="1"/></svg>
-          List Templates
+          Templates
         </a>
         <a href="#thumbnail" class="api-sidebar-link">
           <svg class="api-sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg>
@@ -33,93 +38,90 @@ import '@/styles/api-docs.css';
 
     <!-- Content -->
     <div class="api-content">
-      <h1>API Documentation</h1>
-      <p class="api-intro">
-        Generate OG images, check URL meta tags, and list templates with our free REST API.
-        No API key required. CORS-enabled for browser use.
-      </p>
-
       <!-- Generate Image -->
       <div class="endpoint-card" id="generate">
         <div class="endpoint-header">
           <span class="endpoint-method">GET</span>
-          <span class="endpoint-path">/api/og</span>
-          <a href="#generate" class="section-anchor" aria-label="Link to this section">#</a>
+          <code class="endpoint-path">/api/og</code>
         </div>
-        <p class="endpoint-desc">Generate an OG image as PNG. Returns image/png with Cache-Control headers.</p>
+        <p class="endpoint-desc">Generate an OG image as PNG. Returns <code>image/png</code> with Cache-Control headers.</p>
 
         <h4>Parameters</h4>
-        <table class="param-table">
-          <thead>
-            <tr><th>Param</th><th>Type</th><th>Required</th><th>Description</th></tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="param-name">template</td>
-              <td class="param-type">string</td>
-              <td>No</td>
-              <td class="param-desc">Template ID (default: blog-minimal-dark)</td>
-            </tr>
-            <tr>
-              <td class="param-name">title</td>
-              <td class="param-type">string</td>
-              <td><span class="param-required">Yes</span></td>
-              <td class="param-desc">Main title text</td>
-            </tr>
-            <tr>
-              <td class="param-name">description</td>
-              <td class="param-type">string</td>
-              <td>No</td>
-              <td class="param-desc">Subtitle or description</td>
-            </tr>
-            <tr>
-              <td class="param-name">author</td>
-              <td class="param-type">string</td>
-              <td>No</td>
-              <td class="param-desc">Author name</td>
-            </tr>
-            <tr>
-              <td class="param-name">bgColor</td>
-              <td class="param-type">string</td>
-              <td>No</td>
-              <td class="param-desc">Background color (hex, e.g. #0a0a0a)</td>
-            </tr>
-            <tr>
-              <td class="param-name">accentColor</td>
-              <td class="param-type">string</td>
-              <td>No</td>
-              <td class="param-desc">Accent color (hex)</td>
-            </tr>
-            <tr>
-              <td class="param-name">width</td>
-              <td class="param-type">number</td>
-              <td>No</td>
-              <td class="param-desc">Image width (200-2400, default: 1200)</td>
-            </tr>
-            <tr>
-              <td class="param-name">height</td>
-              <td class="param-type">number</td>
-              <td>No</td>
-              <td class="param-desc">Image height (200-2400, default: 630)</td>
-            </tr>
-          </tbody>
-        </table>
+        <div class="param-list">
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">template</code>
+              <span class="param-type">string</span>
+            </div>
+            <p class="param-desc">Template ID (default: <code>blog-minimal-dark</code>)</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">title</code>
+              <span class="param-type">string</span>
+              <span class="param-required">required</span>
+            </div>
+            <p class="param-desc">Main title text</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">description</code>
+              <span class="param-type">string</span>
+            </div>
+            <p class="param-desc">Subtitle or description</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">author</code>
+              <span class="param-type">string</span>
+            </div>
+            <p class="param-desc">Author name</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">bgColor</code>
+              <span class="param-type">string</span>
+            </div>
+            <p class="param-desc">Background color (hex, e.g. <code>#0a0a0a</code>)</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">accentColor</code>
+              <span class="param-type">string</span>
+            </div>
+            <p class="param-desc">Accent color (hex)</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">width</code>
+              <span class="param-type">number</span>
+            </div>
+            <p class="param-desc">Image width, 200–2400 (default: 1200)</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">height</code>
+              <span class="param-type">number</span>
+            </div>
+            <p class="param-desc">Image height, 200–2400 (default: 630)</p>
+          </div>
+        </div>
 
         <h4>Examples</h4>
         <div class="code-block">
           <div class="code-block-header">
-            <div class="code-block-dots"><span class="code-block-dot"></span><span class="code-block-dot"></span><span class="code-block-dot"></span></div>
-            <span>curl</span>
+            <span class="code-block-lang">curl</span>
             <button class="code-block-copy" data-copy type="button">Copy</button>
           </div>
-          <pre class="code-block-body"><code>curl "https://og.codercops.com/api/og?title=Hello+World&template=blog-minimal-dark" \
+          <pre class="code-block-body"><code>curl "https://og.codercops.com/api/og?\
+title=Hello+World&\
+template=blog-minimal-dark" \
   --output og-image.png</code></pre>
         </div>
 
         <div class="code-block">
           <div class="code-block-header">
-            <div class="code-block-dots"><span class="code-block-dot"></span><span class="code-block-dot"></span><span class="code-block-dot"></span></div>
-            <span>JavaScript</span>
+            <span class="code-block-lang">JavaScript</span>
             <button class="code-block-copy" data-copy type="button">Copy</button>
           </div>
           <pre class="code-block-body"><code>{`const params = new URLSearchParams({
@@ -128,28 +130,30 @@ import '@/styles/api-docs.css';
   author: 'OGCOPS',
 });
 
-const imageUrl = \`https://og.codercops.com/api/og?\${params}\`;
+const url = \`https://og.codercops.com/api/og?\${params}\`;
 
 // Use as meta tag:
-// <meta property="og:image" content={\`\${imageUrl}\`} />`}</code></pre>
+// <meta property="og:image" content={url} />`}</code></pre>
         </div>
 
         <div class="code-block">
           <div class="code-block-header">
-            <div class="code-block-dots"><span class="code-block-dot"></span><span class="code-block-dot"></span><span class="code-block-dot"></span></div>
-            <span>Python</span>
+            <span class="code-block-lang">Python</span>
             <button class="code-block-copy" data-copy type="button">Copy</button>
           </div>
           <pre class="code-block-body"><code>{`import requests
 
-response = requests.get("https://og.codercops.com/api/og", params={
-    "template": "blog-minimal-dark",
-    "title": "Hello World",
-    "author": "OGCOPS",
-})
+resp = requests.get(
+    "https://og.codercops.com/api/og",
+    params={
+        "template": "blog-minimal-dark",
+        "title": "Hello World",
+        "author": "OGCOPS",
+    },
+)
 
 with open("og-image.png", "wb") as f:
-    f.write(response.content)`}</code></pre>
+    f.write(resp.content)`}</code></pre>
         </div>
       </div>
 
@@ -157,34 +161,29 @@ with open("og-image.png", "wb") as f:
       <div class="endpoint-card" id="preview">
         <div class="endpoint-header">
           <span class="endpoint-method">GET</span>
-          <span class="endpoint-path">/api/preview</span>
-          <a href="#preview" class="section-anchor" aria-label="Link to this section">#</a>
+          <code class="endpoint-path">/api/preview</code>
         </div>
         <p class="endpoint-desc">Fetch and analyze meta tags from a URL. Returns JSON with meta tags, analysis score, and per-platform preview data for 8 platforms.</p>
 
         <h4>Parameters</h4>
-        <table class="param-table">
-          <thead>
-            <tr><th>Param</th><th>Type</th><th>Required</th><th>Description</th></tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="param-name">url</td>
-              <td class="param-type">string</td>
-              <td><span class="param-required">Yes</span></td>
-              <td class="param-desc">URL to check (must be a valid URL)</td>
-            </tr>
-          </tbody>
-        </table>
+        <div class="param-list">
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">url</code>
+              <span class="param-type">string</span>
+              <span class="param-required">required</span>
+            </div>
+            <p class="param-desc">URL to check (must be a valid URL)</p>
+          </div>
+        </div>
 
         <h4>Response</h4>
-        <div class="code-block code-block-collapsible">
+        <div class="code-block">
           <div class="code-block-header">
-            <div class="code-block-dots"><span class="code-block-dot"></span><span class="code-block-dot"></span><span class="code-block-dot"></span></div>
-            <span>JSON Response</span>
+            <span class="code-block-lang">JSON Response</span>
             <button class="code-block-copy" data-copy type="button">Copy</button>
           </div>
-          <pre class="code-block-body" id="preview-response"><code>{`{
+          <pre class="code-block-body"><code>{`{
   "url": "https://example.com",
   "meta": {
     "title": "Example",
@@ -196,7 +195,7 @@ with open("og-image.png", "wb") as f:
     "score": 85,
     "grade": "B",
     "issues": [...],
-    "summary": "Good setup with minor improvements possible."
+    "summary": "Good setup."
   },
   "platforms": [
     {
@@ -217,15 +216,13 @@ with open("og-image.png", "wb") as f:
       <div class="endpoint-card" id="templates">
         <div class="endpoint-header">
           <span class="endpoint-method">GET</span>
-          <span class="endpoint-path">/api/templates</span>
-          <a href="#templates" class="section-anchor" aria-label="Link to this section">#</a>
+          <code class="endpoint-path">/api/templates</code>
         </div>
         <p class="endpoint-desc">List all available templates with their fields, defaults, and thumbnail URLs.</p>
 
         <div class="code-block">
           <div class="code-block-header">
-            <div class="code-block-dots"><span class="code-block-dot"></span><span class="code-block-dot"></span><span class="code-block-dot"></span></div>
-            <span>curl</span>
+            <span class="code-block-lang">curl</span>
             <button class="code-block-copy" data-copy type="button">Copy</button>
           </div>
           <pre class="code-block-body"><code>curl "https://og.codercops.com/api/templates"</code></pre>
@@ -236,18 +233,17 @@ with open("og-image.png", "wb") as f:
       <div class="endpoint-card" id="thumbnail">
         <div class="endpoint-header">
           <span class="endpoint-method">GET</span>
-          <span class="endpoint-path">/api/templates/&#123;id&#125;/thumbnail.png</span>
-          <a href="#thumbnail" class="section-anchor" aria-label="Link to this section">#</a>
+          <code class="endpoint-path">/api/templates/&#123;id&#125;/thumbnail.png</code>
         </div>
-        <p class="endpoint-desc">Get a 600x315 thumbnail preview of a template with its default values. Cached for 7 days.</p>
+        <p class="endpoint-desc">Get a 600×315 thumbnail preview of a template with its default values. Cached for 7 days.</p>
 
         <div class="code-block">
           <div class="code-block-header">
-            <div class="code-block-dots"><span class="code-block-dot"></span><span class="code-block-dot"></span><span class="code-block-dot"></span></div>
-            <span>Example</span>
+            <span class="code-block-lang">Example</span>
             <button class="code-block-copy" data-copy type="button">Copy</button>
           </div>
-          <pre class="code-block-body"><code>https://og.codercops.com/api/templates/blog-minimal-dark/thumbnail.png</code></pre>
+          <pre class="code-block-body"><code>https://og.codercops.com/api/templates/\
+blog-minimal-dark/thumbnail.png</code></pre>
         </div>
       </div>
     </div>
@@ -255,34 +251,29 @@ with open("og-image.png", "wb") as f:
 </Layout>
 
 <script is:inline>
-  // Copy buttons for code blocks
-  document.querySelectorAll('[data-copy]').forEach(btn => {
+  document.querySelectorAll('[data-copy]').forEach(function(btn) {
     btn.addEventListener('click', function() {
-      const codeBlock = this.closest('.code-block');
-      const code = codeBlock?.querySelector('code')?.textContent || '';
-      navigator.clipboard.writeText(code).then(() => {
-        this.textContent = 'Copied!';
-        window.showToast?.('Copied to clipboard!', 'success');
-        setTimeout(() => { this.textContent = 'Copy'; }, 2000);
+      var codeBlock = this.closest('.code-block');
+      var code = codeBlock ? (codeBlock.querySelector('code')?.textContent || '') : '';
+      navigator.clipboard.writeText(code).then(function() {
+        btn.textContent = 'Copied!';
+        if (window.showToast) window.showToast('Copied to clipboard!', 'success');
+        setTimeout(function() { btn.textContent = 'Copy'; }, 2000);
       });
     });
   });
 
-  // Sidebar active state on scroll
-  const sidebarLinks = document.querySelectorAll('.api-sidebar-link');
-  const sections = document.querySelectorAll('.endpoint-card[id]');
+  var sidebarLinks = document.querySelectorAll('.api-sidebar-link');
+  var sections = document.querySelectorAll('.endpoint-card[id]');
 
   function updateSidebar() {
-    let current = '';
-    sections.forEach(section => {
-      const rect = section.getBoundingClientRect();
-      if (rect.top <= 120) current = section.id;
+    var current = '';
+    sections.forEach(function(section) {
+      if (section.getBoundingClientRect().top <= 140) current = section.id;
     });
-    if (!current && sections.length) current = 'overview';
-
-    sidebarLinks.forEach(link => {
-      const href = link.getAttribute('href');
-      if (href === '#' + current || (!current && href === '#overview')) {
+    sidebarLinks.forEach(function(link) {
+      var href = link.getAttribute('href');
+      if (href === '#' + current) {
         link.classList.add('active');
       } else {
         link.classList.remove('active');
@@ -291,4 +282,5 @@ with open("og-image.png", "wb") as f:
   }
 
   window.addEventListener('scroll', updateSidebar, { passive: true });
+  updateSidebar();
 </script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,7 +14,7 @@ const categoryCounts = getCategoryCounts();
     <div class="hero-glow"></div>
     <div class="hero-pattern"></div>
     <div class="container hero-inner">
-      <div class="hero-content" data-animate="slide-up">
+      <div class="hero-text" data-animate="slide-up">
         <span class="section-label">Free & Open Source</span>
         <h1><span class="text-gradient">Free</span> OG Image<br />Generator</h1>
         <p class="hero-subtitle">
@@ -26,6 +26,56 @@ const categoryCounts = getCategoryCounts();
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
           </a>
           <a href="/preview" class="btn btn-outline btn-lg">Check Your URL</a>
+        </div>
+        <div class="hero-support">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="var(--accent-primary)" stroke="none"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span>Support this project</span>
+          <a href="https://buymeacoffee.com/codercops" target="_blank" rel="noopener" class="hero-support-link">Buy Me a Coffee</a>
+          <span class="hero-support-dot">&middot;</span>
+          <a href="https://www.paypal.com/paypalme/codercops" target="_blank" rel="noopener" class="hero-support-link">PayPal</a>
+        </div>
+      </div>
+      <div class="hero-visual" data-animate="slide-up" data-animate-delay="2">
+        <div class="og-card-stack">
+          <!-- Card 1 — back (dark template) -->
+          <div class="og-card og-card-1">
+            <div class="og-card-img og-card-img-dark">
+              <span class="og-card-accent-line"></span>
+              <span class="og-card-tag">BLOG</span>
+              <span class="og-card-title-lg">How to Build<br/>a REST API</span>
+            </div>
+            <div class="og-card-meta">
+              <span class="og-card-favicon og-card-favicon-dark"></span>
+              <span>dev.to &middot; 5 min read</span>
+            </div>
+          </div>
+          <!-- Card 2 — middle (coral gradient) -->
+          <div class="og-card og-card-2">
+            <div class="og-card-img og-card-img-coral">
+              <span class="og-card-tag-light">LAUNCH</span>
+              <span class="og-card-title-lg og-card-title-white">Introducing<br/>OGCOPS 2.0</span>
+              <span class="og-card-subtitle-light">Free &middot; Open Source &middot; No Login</span>
+            </div>
+            <div class="og-card-meta">
+              <span class="og-card-favicon og-card-favicon-coral"></span>
+              <span>og.codercops.com</span>
+            </div>
+          </div>
+          <!-- Card 3 — front (light/clean) -->
+          <div class="og-card og-card-3">
+            <div class="og-card-img og-card-img-light">
+              <span class="og-card-tag-dark">PORTFOLIO</span>
+              <span class="og-card-title-lg og-card-title-dark">Sarah Chen<br/>Software Engineer</span>
+            </div>
+            <div class="og-card-meta">
+              <span class="og-card-favicon og-card-favicon-blue"></span>
+              <span>github.com/sarahchen</span>
+            </div>
+          </div>
+          <!-- Floating platform pills -->
+          <span class="platform-pill pill-twitter">Twitter</span>
+          <span class="platform-pill pill-linkedin">LinkedIn</span>
+          <span class="platform-pill pill-discord">Discord</span>
         </div>
       </div>
     </div>
@@ -205,6 +255,14 @@ const categoryCounts = getCategoryCounts();
             Star on GitHub
           </a>
           <a href="/templates" class="btn btn-outline btn-lg">Browse Templates</a>
+          <a href="https://buymeacoffee.com/codercops" class="btn btn-bmc btn-lg" target="_blank" rel="noopener">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 8h1a4 4 0 1 1 0 8h-1"/><path d="M3 8h14v9a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4Z"/><line x1="6" x2="6" y1="2" y2="4"/><line x1="10" x2="10" y1="2" y2="4"/><line x1="14" x2="14" y1="2" y2="4"/></svg>
+            Buy Me a Coffee
+          </a>
+          <a href="https://www.paypal.com/paypalme/codercops" class="btn btn-paypal btn-lg" target="_blank" rel="noopener">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="14" x="2" y="5" rx="2"/><line x1="2" x2="22" y1="10" y2="10"/></svg>
+            PayPal
+          </a>
         </div>
       </div>
     </div>
@@ -225,18 +283,17 @@ const categoryCounts = getCategoryCounts();
 </script>
 
 <style>
-  /* Hero */
+  /* Hero — split layout */
   .hero {
     position: relative;
     padding: var(--space-5xl) 0 var(--space-4xl);
-    text-align: center;
     overflow: hidden;
   }
 
   .hero-glow {
     position: absolute;
     top: -120px;
-    left: 50%;
+    left: 30%;
     transform: translateX(-50%);
     width: 800px;
     height: 500px;
@@ -257,7 +314,18 @@ const categoryCounts = getCategoryCounts();
     -webkit-mask-image: radial-gradient(ellipse 60% 50% at 50% 40%, black 20%, transparent 70%);
   }
 
-  .hero-inner { position: relative; z-index: 1; }
+  .hero-inner {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    gap: var(--space-3xl);
+  }
+
+  .hero-text {
+    flex: 1;
+    min-width: 0;
+  }
 
   .hero h1 {
     font-size: var(--text-7xl);
@@ -270,15 +338,242 @@ const categoryCounts = getCategoryCounts();
     font-size: var(--text-xl);
     color: var(--text-muted);
     max-width: 500px;
-    margin: 0 auto var(--space-xl);
+    margin: 0 0 var(--space-xl);
     line-height: 1.6;
   }
 
   .hero-ctas {
     display: flex;
     gap: var(--space-md);
-    justify-content: center;
     flex-wrap: wrap;
+  }
+
+  /* Support line below CTAs */
+  .hero-support {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    margin-top: var(--space-xl);
+    font-size: var(--text-sm);
+    color: var(--text-subtle);
+  }
+
+  .hero-support span {
+    color: var(--text-subtle);
+  }
+
+  .hero-support-link {
+    color: var(--text-muted);
+    font-weight: 500;
+    text-decoration: none;
+    transition: color var(--transition);
+  }
+
+  .hero-support-link:hover {
+    color: var(--accent-primary);
+  }
+
+  .hero-support-dot {
+    color: var(--border-strong);
+  }
+
+  /* Hero visual — card stack */
+  .hero-visual {
+    display: none;
+    flex: 1;
+    min-width: 0;
+    position: relative;
+    height: 420px;
+  }
+
+  .og-card-stack {
+    position: relative;
+    width: 100%;
+    height: 100%;
+  }
+
+  .og-card {
+    position: absolute;
+    width: 320px;
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    box-shadow: var(--shadow-lg);
+    transition: transform var(--transition-slow), box-shadow var(--transition-slow);
+    border: 1px solid var(--border);
+  }
+
+  .og-card:hover {
+    box-shadow: var(--shadow-xl);
+  }
+
+  .og-card-1 {
+    top: 30px;
+    left: 0;
+    transform: rotate(-6deg);
+    z-index: 1;
+  }
+  .og-card-1:hover { transform: rotate(-6deg) translateY(-4px); }
+
+  .og-card-2 {
+    top: 10px;
+    left: 80px;
+    transform: rotate(3deg);
+    z-index: 2;
+  }
+  .og-card-2:hover { transform: rotate(3deg) translateY(-4px); }
+
+  .og-card-3 {
+    top: 60px;
+    left: 140px;
+    transform: rotate(-1deg);
+    z-index: 3;
+  }
+  .og-card-3:hover { transform: rotate(-1deg) translateY(-4px); }
+
+  /* OG card image area (1200:630 ratio ~ 1.9:1) */
+  .og-card-img {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 1200 / 630;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    padding: 20px;
+    overflow: hidden;
+  }
+
+  .og-card-img-dark {
+    background: linear-gradient(145deg, #1a1a1a, #2a2a2a);
+  }
+
+  .og-card-img-coral {
+    background: var(--gradient-coral);
+  }
+
+  .og-card-img-light {
+    background: linear-gradient(145deg, #f8f8f8, #ffffff);
+  }
+
+  .og-card-accent-line {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: var(--gradient-coral);
+  }
+
+  .og-card-tag,
+  .og-card-tag-light,
+  .og-card-tag-dark {
+    display: inline-block;
+    width: fit-content;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    padding: 3px 8px;
+    border-radius: 4px;
+    margin-bottom: 8px;
+  }
+
+  .og-card-tag {
+    background: var(--accent-primary);
+    color: #fff;
+  }
+  .og-card-tag-light {
+    background: rgba(255, 255, 255, 0.2);
+    color: rgba(255, 255, 255, 0.9);
+  }
+  .og-card-tag-dark {
+    background: rgba(0, 0, 0, 0.08);
+    color: var(--text-muted);
+  }
+
+  .og-card-title-lg {
+    font-family: var(--font-sans);
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 1.2;
+    color: #fff;
+  }
+
+  .og-card-title-white {
+    color: #fff;
+  }
+
+  .og-card-title-dark {
+    color: var(--text);
+  }
+
+  .og-card-subtitle-light {
+    font-size: 10px;
+    color: rgba(255, 255, 255, 0.7);
+    margin-top: 6px;
+  }
+
+  .og-card-meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    font-size: 11px;
+    color: var(--text-muted);
+    background: var(--bg-elevated);
+    border-top: 1px solid var(--border-muted);
+  }
+
+  .og-card-favicon {
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    flex-shrink: 0;
+  }
+  .og-card-favicon-dark { background: #333; }
+  .og-card-favicon-coral { background: var(--accent-primary); }
+  .og-card-favicon-blue { background: #0969da; }
+
+  /* Floating platform pills */
+  .platform-pill {
+    position: absolute;
+    padding: 4px 10px;
+    font-size: 10px;
+    font-weight: 600;
+    border-radius: var(--radius-full);
+    color: #fff;
+    box-shadow: var(--shadow-md);
+    z-index: 4;
+    pointer-events: none;
+    animation: pill-float 4s ease-in-out infinite;
+  }
+
+  .pill-twitter {
+    top: 0;
+    right: 20px;
+    background: #1DA1F2;
+    animation-delay: 0s;
+  }
+  .pill-linkedin {
+    bottom: 40px;
+    left: 10px;
+    background: #0A66C2;
+    animation-delay: 1.3s;
+  }
+  .pill-discord {
+    bottom: 10px;
+    right: 60px;
+    background: #5865F2;
+    animation-delay: 2.6s;
+  }
+
+  @keyframes pill-float {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-8px); }
+  }
+
+  @media (min-width: 1024px) {
+    .hero-visual {
+      display: block;
+    }
   }
 
   /* Bento Grid */
@@ -572,6 +867,32 @@ const categoryCounts = getCategoryCounts();
     gap: var(--space-md);
     justify-content: center;
     margin-top: var(--space-xl);
+    flex-wrap: wrap;
+  }
+
+  /* Branded support buttons */
+  .btn-bmc {
+    background: #FFDD00;
+    color: #000;
+    border: 1px solid #FFDD00;
+    font-weight: 600;
+  }
+  .btn-bmc:hover {
+    background: #e6c800;
+    border-color: #e6c800;
+    box-shadow: 0 4px 16px rgba(255, 221, 0, 0.3);
+  }
+
+  .btn-paypal {
+    background: #0070BA;
+    color: #fff;
+    border: 1px solid #0070BA;
+    font-weight: 600;
+  }
+  .btn-paypal:hover {
+    background: #005ea6;
+    border-color: #005ea6;
+    box-shadow: 0 4px 16px rgba(0, 112, 186, 0.3);
   }
 
   @media (max-width: 1024px) {
@@ -579,10 +900,13 @@ const categoryCounts = getCategoryCounts();
   }
 
   @media (max-width: 768px) {
+    .hero { text-align: center; }
     .hero h1 { font-size: var(--text-4xl); }
-    .hero-glow { width: 400px; height: 300px; }
+    .hero-glow { width: 400px; height: 300px; left: 50%; }
+    .hero-subtitle { margin-left: auto; margin-right: auto; }
+    .hero-ctas { justify-content: center; flex-direction: column; align-items: center; }
+    .hero-support { justify-content: center; flex-wrap: wrap; }
     .api-teaser { grid-template-columns: 1fr; }
-    .hero-ctas { flex-direction: column; align-items: center; }
     .bento-grid { grid-template-columns: 1fr; }
     .features-grid { grid-template-columns: 1fr; }
     .timeline-line { left: 20px; }

--- a/src/styles/api-docs.css
+++ b/src/styles/api-docs.css
@@ -1,335 +1,439 @@
-/* ===== API Docs ===== */
+/* ===== API Docs — Mobile-first ===== */
+
 .api-docs {
-  display: grid;
-  grid-template-columns: 220px 1fr;
-  gap: var(--space-2xl);
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: var(--space-2xl) var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
 }
 
-/* Sidebar */
+/* ===== Hero (title + intro) ===== */
+.api-hero {
+  padding: var(--space-xl) var(--space-md) var(--space-lg);
+}
+
+.api-hero h1 {
+  font-size: var(--text-2xl);
+  margin-bottom: var(--space-sm);
+}
+
+.api-intro {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* ===== Sticky section nav (horizontal tabs on mobile) ===== */
 .api-sidebar {
   position: sticky;
-  top: calc(var(--nav-height) + var(--space-xl));
-  height: fit-content;
+  top: var(--nav-height);
+  z-index: 20;
+  background: var(--bg-frosted);
+  backdrop-filter: saturate(180%) blur(16px);
+  -webkit-backdrop-filter: saturate(180%) blur(16px);
+  border-bottom: 1px solid var(--border);
 }
 
 .api-sidebar-nav {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+  padding: 0 var(--space-md);
+  gap: 0;
+}
+
+.api-sidebar-nav::-webkit-scrollbar {
+  display: none;
 }
 
 .api-sidebar-link {
   display: flex;
   align-items: center;
-  gap: var(--space-sm);
-  padding: var(--space-sm) var(--space-md);
-  font-size: var(--text-sm);
+  gap: 6px;
+  padding: 0 var(--space-md);
+  height: 44px;
+  font-size: var(--text-xs);
+  font-weight: 500;
   color: var(--text-muted);
-  border-radius: var(--radius);
-  border-left: 2px solid transparent;
-  transition: all var(--transition);
+  white-space: nowrap;
+  border-bottom: 2px solid transparent;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+  -webkit-tap-highlight-color: transparent;
+  flex-shrink: 0;
 }
 
-.api-sidebar-link:hover {
+.api-sidebar-link:hover,
+.api-sidebar-link:active {
   color: var(--text);
-  background: var(--bg-surface);
 }
 
 .api-sidebar-link.active {
   color: var(--accent-primary);
-  background: var(--accent-primary-subtle);
-  border-left-color: var(--accent-primary);
-  font-weight: 500;
+  border-bottom-color: var(--accent-primary);
+  font-weight: 600;
 }
 
 .api-sidebar-icon {
+  width: 14px;
+  height: 14px;
+  opacity: 0.5;
   flex-shrink: 0;
-  width: 16px;
-  height: 16px;
-  opacity: 0.7;
 }
 
 .api-sidebar-link.active .api-sidebar-icon {
   opacity: 1;
 }
 
-/* Content */
+/* ===== Content ===== */
 .api-content {
+  padding: var(--space-lg) var(--space-md);
   min-width: 0;
+  max-width: 100%;
 }
 
-.api-content h1 {
-  font-size: var(--text-4xl);
-  margin-bottom: var(--space-md);
-}
-
-.api-intro {
-  font-size: var(--text-lg);
+.api-content h4 {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
   color: var(--text-muted);
-  margin-bottom: var(--space-3xl);
-  max-width: 600px;
+  margin: var(--space-lg) 0 var(--space-md);
 }
 
-/* Section anchors */
-.section-anchor {
-  color: var(--text-subtle);
-  text-decoration: none;
-  opacity: 0;
-  margin-left: var(--space-sm);
-  transition: opacity var(--transition);
-}
-
-.endpoint-card:hover .section-anchor {
-  opacity: 1;
-}
-
-.section-anchor:hover {
-  color: var(--accent-primary);
-}
-
-/* Endpoint Card */
+/* ===== Endpoint Card ===== */
 .endpoint-card {
   background: var(--bg-elevated);
   border: 1px solid var(--border);
-  border-radius: var(--radius-xl);
-  padding: var(--space-xl);
-  margin-bottom: var(--space-2xl);
-  box-shadow: var(--shadow-sm);
-  scroll-margin-top: calc(var(--nav-height) + var(--space-lg));
+  border-radius: var(--radius-lg);
+  padding: var(--space-lg) var(--space-md);
+  margin-bottom: var(--space-lg);
+  box-shadow: var(--shadow-xs);
+  scroll-margin-top: calc(var(--nav-height) + 56px);
 }
 
 .endpoint-header {
   display: flex;
   align-items: center;
-  gap: var(--space-md);
-  margin-bottom: var(--space-lg);
+  gap: var(--space-sm);
+  margin-bottom: var(--space-sm);
+  flex-wrap: wrap;
 }
 
 .endpoint-method {
   display: inline-flex;
-  padding: 4px 12px;
-  font-size: var(--text-xs);
+  align-items: center;
+  padding: 2px 10px;
+  font-size: 11px;
   font-weight: 700;
   text-transform: uppercase;
-  border-radius: var(--radius);
+  border-radius: var(--radius-sm);
   background: rgba(34, 197, 94, 0.12);
   color: #16a34a;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.03em;
+  flex-shrink: 0;
+  line-height: 1.6;
 }
 
 .endpoint-path {
   font-family: var(--font-mono);
-  font-size: var(--text-base);
-  font-weight: 500;
+  font-size: var(--text-sm);
+  font-weight: 600;
   color: var(--text);
+  word-break: break-all;
+  background: none;
+  padding: 0;
 }
 
 .endpoint-desc {
   font-size: var(--text-sm);
   color: var(--text-muted);
-  margin-bottom: var(--space-lg);
+  margin-bottom: var(--space-md);
+  line-height: 1.6;
 }
 
-/* Param Table */
-.param-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: var(--text-sm);
-  margin-bottom: var(--space-lg);
-}
-
-.param-table th {
-  text-align: left;
-  padding: var(--space-sm) var(--space-md);
-  border-bottom: 1px solid var(--border);
-  font-weight: 500;
-  color: var(--text-muted);
-  font-size: var(--text-xs);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.param-table td {
-  padding: var(--space-sm) var(--space-md);
-  border-bottom: 1px solid var(--border-muted);
-  vertical-align: top;
-}
-
-.param-table tr:nth-child(even) td {
+.endpoint-desc code {
+  font-size: 0.85em;
   background: var(--bg-surface);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: var(--font-mono);
 }
 
-.param-table tr:last-child td {
+/* ===== Param list (div-based) ===== */
+.param-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin-bottom: var(--space-md);
+}
+
+.param-item {
+  padding: var(--space-md) 0;
+  border-bottom: 1px solid var(--border-muted);
+}
+
+.param-item:last-child {
   border-bottom: none;
+  padding-bottom: 0;
+}
+
+.param-head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 4px;
 }
 
 .param-name {
   font-family: var(--font-mono);
-  font-size: var(--text-xs);
+  font-size: var(--text-sm);
+  font-weight: 600;
   color: var(--accent-primary);
-  white-space: nowrap;
+  background: none;
+  padding: 0;
 }
 
 .param-type {
   font-family: var(--font-mono);
-  font-size: var(--text-xs);
+  font-size: 11px;
   color: var(--text-subtle);
+  background: var(--bg-surface);
+  padding: 1px 8px;
+  border-radius: var(--radius-sm);
+  line-height: 1.5;
 }
 
 .param-required {
   font-size: 10px;
+  font-weight: 700;
   color: #ef4444;
-  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .param-desc {
-  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  line-height: 1.5;
+  margin: 0;
+  max-width: none;
 }
 
-/* Code Block — Terminal Chrome */
+.param-desc code {
+  font-size: 0.9em;
+  background: var(--bg-surface);
+  padding: 0 4px;
+  border-radius: 3px;
+  font-family: var(--font-mono);
+}
+
+/* ===== Code Block ===== */
 .code-block {
   background: #1a1a1a;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius);
   overflow: hidden;
   margin-bottom: var(--space-md);
-  box-shadow: var(--shadow-md);
 }
 
 .code-block-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 16px;
-  background: #252525;
+  padding: 8px 12px;
+  background: #222;
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  min-height: 36px;
 }
 
-.code-block-header span {
-  font-size: var(--text-xs);
-  color: #888;
+.code-block-lang {
+  font-size: 11px;
+  color: #777;
   font-family: var(--font-mono);
 }
 
-.code-block-dots {
-  display: flex;
-  gap: 6px;
-}
-
-.code-block-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-}
-
-.code-block-dot:nth-child(1) { background: #FF5F57; }
-.code-block-dot:nth-child(2) { background: #FEBC2E; }
-.code-block-dot:nth-child(3) { background: #28C840; }
-
 .code-block-copy {
-  padding: 3px 10px;
+  padding: 4px 12px;
   font-size: 11px;
   font-weight: 500;
-  color: #888;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #777;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all var(--transition);
+  transition: all var(--transition-fast);
+  min-height: 30px;
+  -webkit-tap-highlight-color: transparent;
 }
 
-.code-block-copy:hover {
+.code-block-copy:hover,
+.code-block-copy:active {
   color: #fff;
-  background: rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.12);
 }
 
 .code-block-body {
-  padding: var(--space-md) var(--space-lg);
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  color: #e0e0e0;
-  line-height: 1.7;
-  overflow-x: auto;
   margin: 0;
+  padding: var(--space-md);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: #d4d4d4;
+  line-height: 1.6;
+  white-space: pre;
+  word-break: normal;
+  overflow-wrap: normal;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
-/* Collapsible response */
-.code-block-collapsible {
-  overflow: hidden;
+.code-block-body code {
+  display: block;
+  background: none;
+  padding: 0;
+  font-size: inherit;
 }
 
-.code-block-toggle {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  width: 100%;
-  padding: var(--space-sm) var(--space-md);
-  font-size: var(--text-xs);
-  font-weight: 500;
-  color: #888;
-  background: #1e1e1e;
-  border: none;
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
-  cursor: pointer;
-  transition: color var(--transition);
-}
-
-.code-block-toggle:hover {
-  color: #ccc;
-}
-
-.code-block-toggle svg {
-  transition: transform var(--transition);
-}
-
-.code-block-toggle.expanded svg {
-  transform: rotate(180deg);
-}
-
-.code-tabs {
-  display: flex;
-  gap: var(--space-sm);
-  margin-bottom: var(--space-md);
-}
-
-.code-tab {
-  padding: 4px 10px;
-  font-size: var(--text-xs);
-  font-weight: 500;
-  background: transparent;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  color: var(--text-muted);
-  cursor: pointer;
-  transition: all var(--transition);
-}
-
-.code-tab:hover { border-color: var(--border-strong); color: var(--text); }
-.code-tab.active { background: var(--text); color: var(--bg); border-color: var(--text); }
-
-@media (max-width: 768px) {
-  .api-docs {
-    grid-template-columns: 1fr;
+/* ===== Small phone ===== */
+@media (max-width: 480px) {
+  .api-hero {
+    padding: var(--space-lg) var(--space-sm) var(--space-md);
   }
-  .api-sidebar {
-    position: static;
-    border-bottom: 1px solid var(--border);
-    padding-bottom: var(--space-lg);
+
+  .api-hero h1 {
+    font-size: var(--text-xl);
   }
+
   .api-sidebar-nav {
-    flex-direction: row;
-    overflow-x: auto;
-    gap: var(--space-sm);
+    padding: 0 var(--space-sm);
   }
+
+  .api-content {
+    padding: var(--space-md) var(--space-sm);
+  }
+
+  .endpoint-card {
+    padding: var(--space-md) var(--space-sm);
+    border-radius: var(--radius);
+    margin-bottom: var(--space-md);
+  }
+
+  .code-block-body {
+    padding: var(--space-sm) var(--space-md);
+    font-size: 11px;
+  }
+}
+
+/* ===== Desktop ===== */
+@media (min-width: 769px) {
+  .api-docs {
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    grid-template-rows: auto auto 1fr;
+    gap: 0 var(--space-2xl);
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: var(--space-2xl) var(--space-xl);
+  }
+
+  /* Hero spans full width on desktop */
+  .api-hero {
+    grid-column: 1 / -1;
+    padding: 0 0 var(--space-2xl);
+  }
+
+  .api-hero h1 {
+    font-size: var(--text-4xl);
+    margin-bottom: var(--space-md);
+  }
+
+  .api-intro {
+    font-size: var(--text-lg);
+    max-width: 600px;
+  }
+
+  /* Sidebar: vertical on desktop */
+  .api-sidebar {
+    position: sticky;
+    top: calc(var(--nav-height) + var(--space-xl));
+    height: fit-content;
+    background: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    border-bottom: none;
+    grid-row: 3;
+    grid-column: 1;
+  }
+
+  .api-sidebar-nav {
+    flex-direction: column;
+    overflow-x: visible;
+    padding: 0;
+    gap: 2px;
+  }
+
   .api-sidebar-link {
-    white-space: nowrap;
-    border-left: none;
-    border-bottom: 2px solid transparent;
+    height: auto;
+    padding: var(--space-sm) var(--space-md);
+    font-size: var(--text-sm);
+    border-bottom: none;
+    border-left: 2px solid transparent;
+    border-radius: var(--radius);
   }
+
+  .api-sidebar-link:hover {
+    background: var(--bg-surface);
+  }
+
   .api-sidebar-link.active {
-    border-left-color: transparent;
-    border-bottom-color: var(--accent-primary);
+    background: var(--accent-primary-subtle);
+    border-left-color: var(--accent-primary);
+    border-bottom-color: transparent;
+  }
+
+  .api-sidebar-icon {
+    width: 16px;
+    height: 16px;
+  }
+
+  .api-content {
+    padding: 0;
+    grid-row: 3;
+    grid-column: 2;
+  }
+
+  .endpoint-card {
+    padding: var(--space-xl);
+    margin-bottom: var(--space-2xl);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .endpoint-path {
+    font-size: var(--text-base);
+    word-break: normal;
+  }
+
+  .code-block {
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-md);
+  }
+
+  .code-block-header {
+    padding: 10px 16px;
+  }
+
+  .code-block-body {
+    padding: var(--space-md) var(--space-lg);
+    font-size: var(--text-xs);
+    line-height: 1.7;
+  }
+
+  /* Desktop param list can be a bit wider */
+  .param-desc {
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
   }
 }

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -2,7 +2,9 @@
 .editor-layout {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: 100%;
+  min-height: 100vh;
+  min-height: 100dvh;
   overflow: hidden;
   background: var(--bg);
 }
@@ -41,6 +43,12 @@
   font-size: var(--text-sm);
   color: var(--text-muted);
   margin-right: auto;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.editor-topbar-label {
+  flex-shrink: 0;
 }
 
 .editor-topbar-sep {
@@ -51,6 +59,9 @@
 .editor-topbar-name {
   font-weight: 500;
   color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* ===== Mobile Tabs ===== */
@@ -66,7 +77,7 @@
 
 .mobile-tab {
   flex: 1;
-  padding: var(--space-md);
+  padding: var(--space-md) var(--space-sm);
   font-size: var(--text-sm);
   font-weight: 500;
   color: var(--text-muted);
@@ -75,7 +86,8 @@
   border-bottom: 2px solid transparent;
   cursor: pointer;
   transition: color var(--transition), border-color var(--transition);
-  min-height: 44px;
+  min-height: 48px;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .mobile-tab.active {
@@ -193,6 +205,8 @@
   transition: all var(--transition);
   text-align: left;
   padding: 0;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
 }
 
 .template-thumb:hover { border-color: var(--border-strong); transform: translateY(-2px); box-shadow: var(--shadow-md); }
@@ -203,6 +217,7 @@
   aspect-ratio: 1200 / 630;
   overflow: hidden;
   background: var(--bg-subtle);
+  background-image: linear-gradient(135deg, var(--bg-subtle) 0%, var(--bg-surface) 100%);
 }
 
 .template-thumb-preview img {
@@ -325,6 +340,7 @@
   justify-content: space-between;
   padding: var(--space-md) var(--space-lg);
   border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
 }
 
 .customize-title {
@@ -338,12 +354,24 @@
   font-size: var(--text-xs);
   color: var(--text-subtle);
   background: none;
-  border: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: color var(--transition);
+  transition: all var(--transition);
+  padding: var(--space-sm) var(--space-md);
+  min-height: 36px;
+  -webkit-tap-highlight-color: transparent;
 }
 
-.customize-reset:hover { color: var(--accent-primary); }
+.customize-reset:hover {
+  color: var(--accent-primary);
+  border-color: var(--accent-primary);
+  background: var(--accent-primary-subtle);
+}
+
+.customize-reset:active {
+  transform: scale(0.97);
+}
 
 .customize-fields {
   flex: 1;
@@ -353,6 +381,10 @@
 
 .customize-group {
   margin-bottom: var(--space-lg);
+}
+
+.customize-group:last-child {
+  margin-bottom: 0;
 }
 
 .customize-group-title {
@@ -411,8 +443,10 @@
   appearance: none;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' stroke='%23999' stroke-width='2'%3E%3Cpath d='M2 4l4 4 4-4'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
-  background-position: right 10px center;
-  padding-right: 28px;
+  background-position: right 12px center;
+  padding-right: 32px;
+  min-height: 40px;
+  cursor: pointer;
 }
 
 /* Color Picker */
@@ -430,6 +464,7 @@
   cursor: pointer;
   padding: 2px;
   flex-shrink: 0;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .editor-color-text {
@@ -443,17 +478,21 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  min-height: 44px;
 }
 
 .editor-toggle {
-  width: 40px;
-  height: 22px;
+  width: 44px;
+  height: 26px;
   background: var(--border-strong);
   border: none;
-  border-radius: 11px;
+  border-radius: 13px;
   cursor: pointer;
   position: relative;
   transition: background var(--transition);
+  flex-shrink: 0;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
 }
 
 .editor-toggle.active {
@@ -462,13 +501,14 @@
 
 .editor-toggle-thumb {
   position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 18px;
-  height: 18px;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
   background: white;
   border-radius: 50%;
   transition: transform var(--transition);
+  box-shadow: var(--shadow-xs);
 }
 
 .editor-toggle.active .editor-toggle-thumb {
@@ -491,18 +531,19 @@
 
 .editor-slider {
   width: 100%;
-  height: 4px;
+  height: 6px;
   -webkit-appearance: none;
   appearance: none;
   background: var(--border);
-  border-radius: 2px;
+  border-radius: 3px;
   outline: none;
+  touch-action: manipulation;
 }
 
 .editor-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
-  width: 16px;
-  height: 16px;
+  width: 18px;
+  height: 18px;
   background: var(--accent-primary);
   border-radius: 50%;
   cursor: pointer;
@@ -514,7 +555,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 6px 12px;
+  padding: 8px 14px;
   font-size: var(--text-xs);
   font-weight: 500;
   color: var(--text-muted);
@@ -524,11 +565,17 @@
   cursor: pointer;
   margin-top: 6px;
   transition: all var(--transition);
+  -webkit-tap-highlight-color: transparent;
+  min-height: 40px;
 }
 
 .editor-upload-btn:hover {
   border-color: var(--border-strong);
   color: var(--text);
+}
+
+.editor-upload-btn:active {
+  transform: scale(0.97);
 }
 
 /* ===== Export Bar ===== */
@@ -547,7 +594,7 @@
 .export-btn {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   padding: 6px 14px;
   font-size: var(--text-xs);
   font-weight: 500;
@@ -556,6 +603,12 @@
   border: 1px solid transparent;
   transition: all var(--transition);
   white-space: nowrap;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+.export-btn:active {
+  transform: scale(0.97);
 }
 
 .export-btn-primary {
@@ -566,15 +619,17 @@
 }
 
 .export-btn-primary:hover { box-shadow: var(--shadow-md), var(--shadow-glow); }
-.export-btn-primary:disabled { opacity: 0.6; cursor: not-allowed; }
+.export-btn-primary:active { box-shadow: var(--shadow-xs); }
+.export-btn-primary:disabled { opacity: 0.6; cursor: not-allowed; transform: none; }
 
 .export-btn-ghost {
-  background: transparent;
+  background: var(--bg-elevated);
   color: var(--text-muted);
   border-color: var(--border);
 }
 
 .export-btn-ghost:hover { background: var(--bg-surface); color: var(--text); border-color: var(--border-strong); }
+.export-btn-ghost:active { background: var(--bg-surface); }
 
 /* ===== Platform Preview Strip ===== */
 .platform-strip {
@@ -602,6 +657,7 @@
   overflow-x: auto;
   padding-bottom: var(--space-sm);
   scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
 }
 
 .platform-strip-scroll::-webkit-scrollbar { display: none; }
@@ -611,11 +667,17 @@
   cursor: pointer;
   border-radius: var(--radius);
   transition: transform var(--transition), box-shadow var(--transition);
+  min-width: 120px;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .platform-mini:hover {
   transform: translateY(-2px) scale(1.02);
   box-shadow: var(--shadow-md);
+}
+
+.platform-mini:active {
+  transform: scale(0.98);
 }
 
 .platform-mini-header {
@@ -701,8 +763,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--space-xl);
+  padding: var(--space-md);
   animation: fadeIn 0.15s ease-out;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .platform-expanded-card {
@@ -756,24 +819,69 @@
 
 .platform-expanded-body {
   padding: var(--space-lg);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.platform-expanded-close {
+  min-width: 44px;
+  min-height: 44px;
 }
 
 /* ===== Export Mobile ===== */
 .editor-export-mobile {
-  padding: var(--space-xl);
+  padding: var(--space-lg) var(--space-md);
+  padding-bottom: max(var(--space-xl), env(safe-area-inset-bottom));
   display: flex;
   flex-direction: column;
-  gap: var(--space-md);
+  gap: var(--space-lg);
+  width: 100%;
+}
+
+.editor-export-preview {
+  display: none;
 }
 
 .editor-export-mobile .export-bar {
   flex-direction: column;
 }
 
+.editor-export-mobile .export-buttons {
+  flex-direction: column;
+  width: 100%;
+  gap: var(--space-sm);
+}
+
 .editor-export-mobile .export-btn {
   width: 100%;
-  padding: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
   font-size: var(--text-sm);
+  min-height: 52px;
+  justify-content: center;
+  border-radius: var(--radius-lg);
+}
+
+.editor-export-mobile .export-btn-primary {
+  font-size: var(--text-base);
+  font-weight: 600;
+  gap: var(--space-sm);
+  min-height: 56px;
+}
+
+.editor-export-mobile .export-btn-primary svg {
+  width: 18px;
+  height: 18px;
+}
+
+.editor-export-mobile .export-btn-ghost {
+  background: var(--bg-surface);
+  border-color: var(--border);
+}
+
+.editor-export-mobile .platform-strip {
+  margin-top: var(--space-sm);
+  border-top: 1px solid var(--border-muted);
+  padding-top: var(--space-lg);
 }
 
 /* ===== Responsive ===== */
@@ -786,20 +894,374 @@
   .editor-topbar .export-bar { display: none; }
   .editor-mobile-tabs-wrapper { display: block; }
 
-  .editor-panels { flex-direction: column; }
-  .editor-left,
-  .editor-right {
+  .editor-topbar {
+    gap: var(--space-sm);
+  }
+
+  .editor-topbar-label {
+    display: none;
+  }
+
+  .editor-logo-img {
+    height: 20px;
+  }
+
+  .editor-panels {
+    flex-direction: column;
+    overflow-y: auto;
+    overflow-x: hidden;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .editor-left {
     width: 100%;
     border-left: none;
     border-right: none;
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
   }
 
-  .editor-left { height: 100%; }
-  .editor-center { height: 100%; padding: var(--space-md); }
-  .editor-right { height: 100%; }
+  .editor-center {
+    width: 100%;
+    height: auto;
+    min-height: auto;
+    flex: none;
+    padding: var(--space-md);
+    overflow: visible;
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    background: var(--bg);
+    border-bottom: 1px solid var(--border-muted);
+  }
+
+  .editor-right {
+    width: 100%;
+    min-height: 0;
+    border-left: none;
+    border-right: none;
+    flex: 1 1 auto;
+    flex-direction: column;
+    overflow: visible;
+  }
+
+  .editor-center .canvas-wrapper {
+    min-height: 200px;
+    max-height: 35vh;
+    flex-shrink: 0;
+    border-radius: var(--radius);
+  }
+
+  .editor-center .platform-strip {
+    display: none;
+  }
+
+  .editor-right .customize-panel {
+    height: auto;
+    width: 100%;
+    padding-bottom: max(var(--space-lg), env(safe-area-inset-bottom));
+  }
+
+  .editor-right .customize-header {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background: var(--bg-elevated);
+    padding: var(--space-sm) var(--space-md);
+    backdrop-filter: saturate(180%) blur(12px);
+    -webkit-backdrop-filter: saturate(180%) blur(12px);
+  }
+
+  .editor-right .customize-fields {
+    padding: var(--space-md);
+    overflow: visible;
+  }
+
+  .editor-right .customize-group-title {
+    position: sticky;
+    top: 0;
+    background: var(--bg);
+    padding-top: var(--space-sm);
+    z-index: 1;
+  }
+
+  .editor-export-preview {
+    display: block;
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    box-shadow: var(--shadow-md);
+  }
+
+  .editor-export-preview .canvas-wrapper {
+    min-height: 120px;
+    max-height: 28vh;
+    border-radius: var(--radius-lg);
+  }
+
+  .editor-field-textarea {
+    min-height: 80px;
+  }
+
+  .editor-select {
+    font-size: 16px;
+    min-height: 44px;
+  }
+
+  .editor-upload-btn {
+    width: 100%;
+    min-height: 44px;
+    justify-content: center;
+  }
+
+  .editor-toggle {
+    width: 48px;
+    height: 28px;
+    border-radius: 14px;
+  }
+
+  .editor-toggle-thumb {
+    width: 22px;
+    height: 22px;
+  }
+
+  .editor-toggle.active .editor-toggle-thumb {
+    transform: translateX(20px);
+  }
 
   .mobile-hide { display: none !important; }
   .mobile-show { display: flex !important; }
 
-  .template-grid { grid-template-columns: repeat(2, 1fr); }
+  .template-grid {
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+    flex: 1;
+    align-content: start;
+  }
+
+  .template-thumb {
+    min-height: 0;
+    border-radius: var(--radius-sm);
+  }
+
+  .template-thumb:active {
+    transform: scale(0.97);
+    box-shadow: none;
+  }
+
+  .template-thumb-preview {
+    border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  }
+
+  .platform-strip-header {
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+  }
+
+  .platform-strip-scroll {
+    margin-left: calc(-1 * var(--space-md));
+    margin-right: calc(-1 * var(--space-md));
+    padding-left: var(--space-md);
+    padding-right: var(--space-md);
+    gap: var(--space-sm);
+  }
+
+  .platform-expanded-overlay {
+    padding: var(--space-sm);
+    align-items: flex-end;
+  }
+
+  .platform-expanded-card {
+    max-height: 85vh;
+    max-height: 85dvh;
+    overflow-y: auto;
+    border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+  }
+
+  .platform-expanded-header {
+    padding: var(--space-md);
+    position: sticky;
+    top: 0;
+    background: var(--bg-elevated);
+    z-index: 1;
+  }
+
+  .platform-expanded-body {
+    padding: var(--space-md);
+  }
+
+  .viewport-switcher-compact .viewport-btn {
+    padding: 6px 10px;
+    min-height: 36px;
+  }
+
+  .template-panel-header {
+    padding: var(--space-sm) var(--space-md);
+  }
+
+  .template-search {
+    font-size: 16px;
+    min-height: 44px;
+    padding: var(--space-sm) var(--space-md);
+  }
+
+  .template-categories {
+    padding: var(--space-xs) var(--space-md);
+  }
+
+  .editor-color-swatch {
+    width: 44px;
+    height: 44px;
+  }
+
+  .editor-slider::-webkit-slider-thumb {
+    width: 24px;
+    height: 24px;
+  }
+}
+
+/* Small phones: larger touch targets, tighter spacing */
+@media (max-width: 480px) {
+  .editor-topbar {
+    padding: 0 var(--space-sm);
+    min-height: 44px;
+    height: 44px;
+    gap: var(--space-xs);
+  }
+
+  .editor-topbar-name {
+    font-size: var(--text-xs);
+  }
+
+  .editor-logo-img {
+    height: 18px;
+  }
+
+  .mobile-tab {
+    font-size: var(--text-xs);
+    min-height: 44px;
+    padding: var(--space-sm) var(--space-xs);
+  }
+
+  .editor-center {
+    padding: var(--space-sm);
+  }
+
+  .editor-center .canvas-wrapper {
+    min-height: 180px;
+    max-height: 36vh;
+  }
+
+  .customize-fields {
+    padding: var(--space-sm) var(--space-md);
+  }
+
+  .editor-field {
+    margin-bottom: var(--space-lg);
+  }
+
+  .editor-field-label {
+    font-size: var(--text-sm);
+    margin-bottom: 6px;
+  }
+
+  .editor-field-input {
+    font-size: 16px;
+    min-height: 48px;
+    padding: 12px 14px;
+    border-radius: var(--radius);
+  }
+
+  .editor-field-textarea {
+    min-height: 90px;
+  }
+
+  .editor-color-swatch {
+    width: 48px;
+    height: 48px;
+    border-radius: var(--radius);
+  }
+
+  .editor-color-text {
+    font-size: var(--text-sm);
+    min-height: 48px;
+  }
+
+  .editor-slider {
+    height: 8px;
+    border-radius: 4px;
+  }
+
+  .editor-slider::-webkit-slider-thumb {
+    width: 28px;
+    height: 28px;
+  }
+
+  .editor-select {
+    min-height: 48px;
+    border-radius: var(--radius);
+  }
+
+  .editor-upload-btn {
+    min-height: 48px;
+    font-size: var(--text-sm);
+    border-radius: var(--radius);
+  }
+
+  .editor-export-mobile {
+    padding: var(--space-md);
+  }
+
+  .editor-export-mobile .export-btn {
+    min-height: 52px;
+    border-radius: var(--radius);
+  }
+
+  .editor-export-mobile .export-btn-primary {
+    min-height: 56px;
+  }
+
+  .editor-export-preview .canvas-wrapper {
+    min-height: 100px;
+    max-height: 25vh;
+  }
+
+  .template-cat-pill {
+    min-height: 40px;
+    padding: 8px 14px;
+    font-size: 10px;
+  }
+
+  .template-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .template-thumb-name {
+    font-size: 10px;
+    padding: 5px 6px;
+  }
+}
+
+/* Very narrow phones */
+@media (max-width: 380px) {
+  .template-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .customize-group-title {
+    font-size: 10px;
+  }
+
+  .editor-export-mobile .export-btn-primary {
+    font-size: var(--text-sm);
+    min-height: 52px;
+  }
+
+  .platform-mini {
+    min-width: 100px;
+  }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -628,7 +628,7 @@ p {
 }
 
 @media (max-width: 768px) {
-  :root { --space-5xl: 4rem; --space-4xl: 3rem; --space-3xl: 2.5rem; }
+  :root { --space-5xl: 4rem; --space-4xl: 3rem; --space-3xl: 2.5rem; --nav-height: 56px; }
   h1 { font-size: var(--text-3xl); }
   h2 { font-size: var(--text-2xl); }
   .section { padding: var(--space-4xl) 0; }
@@ -640,6 +640,7 @@ p {
 }
 
 @media (max-width: 480px) {
+  :root { --nav-height: 52px; }
   .container { padding: 0 var(--space-md); }
 }
 

--- a/src/styles/preview.css
+++ b/src/styles/preview.css
@@ -479,9 +479,91 @@
 .viewport-btn-active .viewport-btn-size { color: var(--accent-primary); }
 
 @media (max-width: 768px) {
-  .preview-url-row { flex-direction: column; }
-  .platform-grid { grid-template-columns: 1fr; }
-  .meta-report-header { flex-direction: column; text-align: center; }
-  .platform-section-header { flex-direction: column; align-items: flex-start; }
-  .viewport-btn-label { display: none; }
+  .preview-app {
+    padding: var(--space-xl) var(--space-md);
+  }
+
+  .preview-header h1 {
+    font-size: var(--text-2xl);
+  }
+
+  .preview-header p {
+    font-size: var(--text-base);
+  }
+
+  .preview-url-row {
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+
+  .preview-url-field {
+    font-size: 16px; /* Prevents iOS zoom on focus */
+    min-height: 48px;
+    padding: var(--space-md) var(--space-lg);
+  }
+
+  .preview-url-btn {
+    width: 100%;
+    min-height: 48px;
+    padding: var(--space-lg);
+    font-size: var(--text-base);
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .platform-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .meta-report {
+    padding: var(--space-lg);
+  }
+
+  .meta-report-header {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .meta-score {
+    width: 72px;
+    height: 72px;
+  }
+
+  .platform-section-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .viewport-btn-label {
+    display: none;
+  }
+
+  .platform-card-mockup {
+    padding: var(--space-md);
+    min-height: 100px;
+  }
+
+  .fix-it-actions {
+    flex-direction: column;
+  }
+
+  .fix-it-actions a,
+  .fix-it-actions button {
+    width: 100%;
+    min-height: 48px;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .preview-app {
+    padding: var(--space-lg) var(--space-sm);
+  }
+
+  .preview-header {
+    margin-bottom: var(--space-xl);
+  }
+
+  .preview-header h1 {
+    font-size: var(--text-xl);
+  }
 }


### PR DESCRIPTION
## Release v1.2.0

Hero section redesign with support buttons for the project.

### Enhancements
- Redesigned hero with split layout: text+CTAs on left, floating OG card mockup stack on right (desktop)
- Three fanned mockup cards showcasing different template styles (blog, launch, portfolio)
- Floating platform pills (Twitter, LinkedIn, Discord) with bobbing animation
- Subtle support line below hero CTAs with Buy Me a Coffee and PayPal links
- Branded support buttons (BMC yellow, PayPal blue) in Open Source banner section

### Docs & Chores
- Added feedback link to footer
- Renamed main branch references to production

### Test Plan
- [x] `npm run check` — 0 errors
- [x] `npm run test` — 25/25 passed
- [x] `npm run build` — succeeds
- [ ] Manual testing on desktop and mobile
- [ ] Verify support links open correctly

Closes #7