### PR TITLE
Fix extra query params not overriding template defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, dev]
+    branches: [production, dev]
   pull_request:
-    branches: [main, dev]
+    branches: [production, dev]
 
 jobs:
   build:

--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -2,16 +2,16 @@ name: PR Target Check
 
 on:
   pull_request:
-    branches: [main]
+    branches: [production]
 
 jobs:
   check-source-branch:
     runs-on: ubuntu-latest
     steps:
-      - name: Only allow PRs from dev to main
+      - name: Only allow PRs from dev to production
         if: github.head_ref != 'dev'
         run: |
-          echo "::error::PRs targeting 'main' are only allowed from the 'dev' branch."
+          echo "::error::PRs targeting 'production' are only allowed from the 'dev' branch."
           echo "Please target 'dev' instead, or merge your branch into 'dev' first."
           echo ""
           echo "  Source: ${{ github.head_ref }}"
@@ -19,4 +19,4 @@ jobs:
           exit 1
       - name: PR source branch is valid
         if: github.head_ref == 'dev'
-        run: echo "PR from 'dev' to 'main' — allowed."
+        run: echo "PR from 'dev' to 'production' — allowed."

--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -8,15 +8,15 @@ jobs:
   check-source-branch:
     runs-on: ubuntu-latest
     steps:
-      - name: Only allow PRs from dev to production
-        if: github.head_ref != 'dev'
+      - name: Only allow PRs from dev or release branches to production
+        if: github.head_ref != 'dev' && !startsWith(github.head_ref, 'release/')
         run: |
-          echo "::error::PRs targeting 'production' are only allowed from the 'dev' branch."
+          echo "::error::PRs targeting 'production' are only allowed from 'dev' or 'release/*' branches."
           echo "Please target 'dev' instead, or merge your branch into 'dev' first."
           echo ""
           echo "  Source: ${{ github.head_ref }}"
           echo "  Target: ${{ github.base_ref }}"
           exit 1
       - name: PR source branch is valid
-        if: github.head_ref == 'dev'
-        run: echo "PR from 'dev' to 'production' — allowed."
+        if: github.head_ref == 'dev' || startsWith(github.head_ref, 'release/')
+        run: echo "PR from '${{ github.head_ref }}' to 'production' — allowed."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ OGCOPS supports AI-powered features using a Bring Your Own Key (BYOK) model. Use
 - `src/components/preview/AIAnalyzer.tsx` — AI meta tag analysis
 - `src/styles/ai.css` — All AI component styles
 
+
 ## Conventions
 - CSS custom properties only (no Tailwind). Accent: `#E07A5F`.
 - TypeScript strict mode. Path alias `@/*` → `src/*`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,16 +1,21 @@
 # CLAUDE.md — OGCOPS
 
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 ## What is this?
-OGCOPS is a free, open-source OG image generator and social media preview checker. Built with Astro + React Islands, deployed to Vercel.
+OGCOPS is a free, open-source OG image generator and social media preview checker. Built with Astro SSR + React Islands, deployed to Vercel at og.codercops.com. GitHub: github.com/codercops/ogcops. MIT licensed.
 
 ## Commands
 ```bash
-npm run dev          # Start dev server
-npm run build        # Production build
-npm run preview      # Preview production build
-npm run test         # Run vitest
-npm run test:watch   # Watch mode
-npm run check        # Type-check (astro check + tsc)
+npm run dev              # Start dev server (port 4321)
+npm run build            # Production build
+npm run preview          # Preview production build
+npm run test             # Run vitest (single run)
+npm run test:watch       # Watch mode
+npm run test:ui          # Vitest UI
+npm run check            # Type-check (astro check + tsc --noEmit)
+npm run lint             # Astro linting
+npm run generate:favicons  # Generate favicon assets
 ```
 
 ## Architecture
@@ -19,20 +24,32 @@ npm run check        # Type-check (astro check + tsc)
 - **Satori** runs client-side for instant SVG preview (zero server calls during editing)
 - **Satori + resvg-wasm** runs server-side for PNG generation (`/api/og`)
 - **No database** — state lives in URL query params + client-side useReducer
-- **CORS-open API** for developer use
+- **CORS-open API** — no API key, no rate limits
 
 ## Key Directories
-- `src/templates/` — 109 templates across 12 categories. Each template is a `.ts` file exporting a `TemplateDefinition`.
-- `src/lib/` — Core engine (og-engine.ts, font-loader.ts, meta-fetcher.ts, meta-analyzer.ts)
+- `src/templates/` — 120 templates across 12 categories. Each is a `.ts` file exporting a `TemplateDefinition`.
+- `src/lib/` — Core engine (og-engine.ts, font-loader.ts, meta-fetcher.ts, meta-analyzer.ts, api-validation.ts)
 - `src/components/editor/` — React components for the OG image editor
 - `src/components/preview/` — React components for the social media preview checker
-- `src/pages/api/` — API endpoints (og, preview, templates)
+- `src/pages/api/` — API endpoints
+- `src/styles/` — CSS files (global.css, editor.css, preview.css, api-docs.css)
+- `public/fonts/` — Bundled .woff fonts (Inter, Playfair Display, JetBrains Mono)
+- `tests/` — Vitest tests (api/, lib/, templates/)
 
-## Conventions
-- CSS custom properties only (no Tailwind). Accent: `#E07A5F`.
-- TypeScript strict mode. Path alias `@/*` → `src/*`.
-- Fonts bundled as `.woff` in `public/fonts/`.
-- Templates follow `TemplateDefinition` interface in `src/templates/types.ts`.
+## Pages & API Endpoints
+
+**Pages:**
+- `/` — Homepage
+- `/create/` — OG image editor
+- `/templates` — Template gallery
+- `/preview` — Social media preview checker
+- `/api-docs` — API documentation
+
+**API (all CORS-open, no auth):**
+- `GET /api/og?template={id}&...` — Generate PNG (1200x630, 24h cache)
+- `GET /api/preview?url={url}` — Fetch and analyze a URL's meta tags
+- `GET /api/templates` — List all templates as JSON
+- `GET /api/templates/[id]/thumbnail.png` — Template thumbnail (1-week cache)
 
 ## Reference Files
 - Template interface: `src/templates/types.ts`
@@ -42,11 +59,33 @@ npm run check        # Type-check (astro check + tsc)
 - API validation schemas: `src/lib/api-validation.ts`
 - Template registry: `src/templates/registry.ts`
 
-## Template Contribution
-1. Create `src/templates/{category}/{id}.ts`
-2. Export a `TemplateDefinition`
-3. Register in `src/templates/{category}/index.ts`
+## Template System
+
+120 templates across 12 categories: blog, product, saas, github, event, podcast, developer, newsletter, quote, ecommerce, job, tutorial.
+
+**Adding a template:**
+1. Create `src/templates/{category}/{id}.ts` exporting a `TemplateDefinition`
+2. Register in `src/templates/{category}/index.ts`
+3. Add import + registration in `src/templates/registry.ts`
 4. Run `npm run test` to verify
+
+**Template field types:** text, textarea, color, select, number, toggle, image.
+**Field groups:** Content, Style, Brand.
+
+## Conventions
+- CSS custom properties only (no Tailwind). Accent: `#E07A5F`.
+- TypeScript strict mode. Path alias `@/*` → `src/*`.
+- Fonts bundled as `.woff` in `public/fonts/` (Inter Regular/Medium/SemiBold/Bold, Playfair Display Regular/Bold, JetBrains Mono Regular/Bold).
+- Node 22 (`.nvmrc`).
+- Testing: Vitest with node environment. Tests in `tests/**/*.test.ts`. Globals enabled.
+
+## CI/CD
+- Runs on push to `production`/`dev` and PRs to those branches
+- Steps: `npm run check` → `npm run test` → `npm run build`
+- **Branch strategy:** `dev` is the default branch. PRs target `dev`. Releases go `dev` → `production`. Direct PRs to `production` are blocked unless from `dev`.
+
+## Environment Variables (`.env.local`, all optional)
+- `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN` — Optional visitor counter
 
 ## Gotchas / Constraints
 - Satori does **not** support CSS grid — only flexbox
@@ -55,6 +94,7 @@ npm run check        # Type-check (astro check + tsc)
 - Font files must be listed in `astro.config.mjs` `includeFiles` array for Vercel deployment
 - WASM imports need `optimizeDeps.exclude` in the Vite config
 - `renderToPng` returns `ArrayBuffer` (not `Buffer`) for `BodyInit` compatibility
+- Canvas is always 1200x630px
 
 ## Do NOT
 - Add Tailwind CSS — the project uses CSS custom properties only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,12 +29,14 @@ npm run generate:favicons  # Generate favicon assets
 ## Key Directories
 - `src/templates/` — 120 templates across 12 categories. Each is a `.ts` file exporting a `TemplateDefinition`.
 - `src/lib/` — Core engine (og-engine.ts, font-loader.ts, meta-fetcher.ts, meta-analyzer.ts, api-validation.ts)
-- `src/components/editor/` — React components for the OG image editor
-- `src/components/preview/` — React components for the social media preview checker
+- `src/lib/ai/` — AI integration (types, providers, storage, validation, prompts, generate, autofill, recommender)
+- `src/components/editor/` — React components for the OG image editor (includes AI components)
+- `src/components/preview/` — React components for the social media preview checker (includes AIAnalyzer)
 - `src/pages/api/` — API endpoints
-- `src/styles/` — CSS files (global.css, editor.css, preview.css, api-docs.css)
+- `src/pages/api/ai/` — AI proxy endpoints (generate, validate, autofill)
+- `src/styles/` — CSS files (global.css, editor.css, preview.css, api-docs.css, ai.css)
 - `public/fonts/` — Bundled .woff fonts (Inter, Playfair Display, JetBrains Mono)
-- `tests/` — Vitest tests (api/, lib/, templates/)
+- `tests/` — Vitest tests (api/, ai/, lib/, templates/)
 
 ## Pages & API Endpoints
 
@@ -51,6 +53,11 @@ npm run generate:favicons  # Generate favicon assets
 - `GET /api/templates` — List all templates as JSON
 - `GET /api/templates/[id]/thumbnail.png` — Template thumbnail (1-week cache)
 
+**AI API (BYOK — user provides their own API key):**
+- `POST /api/ai/generate` — Proxy text generation to any supported provider
+- `POST /api/ai/validate` — Validate an AI provider API key
+- `POST /api/ai/autofill` — Analyze a URL and auto-fill template fields via AI
+
 ## Reference Files
 - Template interface: `src/templates/types.ts`
 - Reference template: `src/templates/blog/minimal-dark.ts`
@@ -58,6 +65,10 @@ npm run generate:favicons  # Generate favicon assets
 - OG engine: `src/lib/og-engine.ts`
 - API validation schemas: `src/lib/api-validation.ts`
 - Template registry: `src/templates/registry.ts`
+- AI types & provider configs: `src/lib/ai/types.ts`, `src/lib/ai/providers.ts`
+- AI validation schemas: `src/lib/ai/validation.ts`
+- AI prompt builders: `src/lib/ai/prompts.ts`
+- AI context & hook: `src/components/editor/AIContext.tsx`
 
 ## Template System
 
@@ -71,6 +82,29 @@ npm run generate:favicons  # Generate favicon assets
 
 **Template field types:** text, textarea, color, select, number, toggle, image.
 **Field groups:** Content, Style, Brand.
+
+## AI Integration (BYOK)
+
+OGCOPS supports AI-powered features using a Bring Your Own Key (BYOK) model. Users configure their own API keys in the browser; keys are stored in localStorage and passed through server-side proxy endpoints (never stored server-side).
+
+**Supported providers:** OpenAI, Anthropic, Google (Gemini), Groq, OpenRouter.
+**Three API formats:** OpenAI-compatible (OpenAI/Groq/OpenRouter), Anthropic, Google Gemini.
+
+**AI Features:**
+- **AI Copy Generator** — Generate title/subtitle/field suggestions inline in the editor
+- **Smart Autofill** — Paste a URL to auto-select a template and fill all fields
+- **AI Template Recommender** — Natural language template search in the template panel
+- **AI Meta Analyzer** — AI-powered analysis of meta tag quality in the preview checker
+
+**Key files:**
+- `src/lib/ai/` — All AI logic (types, providers, storage, validation, prompts, generate, autofill, recommender)
+- `src/components/editor/AIContext.tsx` — React context providing `generate()`, `isConfigured`, `openSettings`
+- `src/components/editor/AISettingsModal.tsx` — Provider/key/model configuration modal
+- `src/components/editor/AIGenerateButton.tsx` + `AISuggestionPicker.tsx` — Inline copy generation
+- `src/components/editor/AIAutofill.tsx` — Smart autofill from URL
+- `src/components/editor/AITemplateSearch.tsx` — AI template recommender
+- `src/components/preview/AIAnalyzer.tsx` — AI meta tag analysis
+- `src/styles/ai.css` — All AI component styles
 
 ## Conventions
 - CSS custom properties only (no Tailwind). Accent: `#E07A5F`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ npm run build        # Full production build
 1. Fork the repo and create a branch: `git checkout -b feat/my-feature`
 2. Make your changes
 3. Ensure `npm run check` and `npm run test` pass
-4. Push and open a PR against `main`
+4. Push and open a PR against `dev`
 5. Fill out the [PR template](.github/PULL_REQUEST_TEMPLATE.md) — screenshots are required for visual changes
 6. Wait for review
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ OGCOPS is different:
 ## Quick Start
 
 ```bash
-git clone https://github.com/codercops/ogcops.git
+git clone -b dev https://github.com/codercops/ogcops.git
 cd ogcops
 npm install
 npm run dev
@@ -113,6 +113,16 @@ The build output in `dist/` can be deployed to any Node.js hosting platform.
 ## Contributing
 
 Contributions are welcome — templates, bug fixes, features, docs, and more. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup and guidelines.
+
+> **Important:** Always fork and branch from `dev` (the default branch). The `production` branch is for releases only. PRs targeting `production` directly will be closed.
+
+```bash
+# Fork the repo on GitHub, then:
+git clone https://github.com/<your-username>/ogcops.git
+cd ogcops
+git checkout dev
+git checkout -b your-feature-branch
+```
 
 - [Open an issue](https://github.com/codercops/ogcops/issues) — bug reports and feature requests
 - [Start a discussion](https://github.com/codercops/ogcops/discussions) — questions, ideas, show & tell

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,162 @@
+# Release Process
+
+This document describes the step-by-step process for creating a production release of OGCOPS.
+
+## Branch Strategy
+
+```
+feature branches → PR to dev (upstream) → merge → PR to production → merge → release → sync back to dev
+```
+
+| Branch | Purpose |
+|--------|---------|
+| `dev` | Default branch. All feature PRs target this branch. |
+| `production` | Stable release branch. Only accepts PRs from `dev`. |
+
+## Versioning
+
+We follow [Semantic Versioning](https://semver.org/):
+
+- **`patch`** (1.0.0 → 1.0.1): Bug fixes, minor CSS tweaks
+- **`minor`** (1.0.0 → 1.1.0): New features, new templates, UI improvements
+- **`major`** (1.0.0 → 2.0.0): Breaking API changes, major redesigns
+
+## Pre-Release Checklist
+
+- [ ] All feature PRs merged into `dev`
+- [ ] `npm run check` passes (TypeScript + Astro type-check)
+- [ ] `npm run test` passes
+- [ ] `npm run build` succeeds
+- [ ] Manual testing on desktop and mobile
+- [ ] No unresolved critical issues
+
+## Release Steps
+
+### 1. Verify dev is clean
+
+```bash
+cd ogcops
+git fetch upstream
+git checkout dev
+git pull upstream dev
+npm run check && npm run test && npm run build
+```
+
+### 2. Create a release PR (dev → production)
+
+```bash
+gh pr create \
+  --repo codercops/ogcops \
+  --head dev \
+  --base production \
+  --title "release: vX.Y.Z — Short description" \
+  --body "$(cat <<'EOF'
+## Release vX.Y.Z
+
+Brief summary of what's in this release.
+
+### Fixes
+- ...
+
+### Enhancements
+- ...
+
+### Docs & Chores
+- ...
+
+### Test Plan
+- [ ] ...
+
+EOF
+)"
+```
+
+### 3. Review and merge the PR
+
+- Ensure CI passes on the PR
+- Review the diff one final time
+- **Squash and merge** into `production`
+
+### 4. Create the GitHub Release
+
+```bash
+gh release create vX.Y.Z \
+  --repo codercops/ogcops \
+  --target production \
+  --title "vX.Y.Z — Short description" \
+  --notes "$(cat <<'EOF'
+## What's Changed
+
+### Fixes
+- ...
+
+### Enhancements
+- ...
+
+### Docs & Chores
+- ...
+
+**Full Changelog**: https://github.com/codercops/ogcops/compare/vPREVIOUS...vX.Y.Z
+
+EOF
+)"
+```
+
+### 5. Sync production back into dev
+
+Since `dev` has branch protection, create a sync PR:
+
+```bash
+gh pr create \
+  --repo codercops/ogcops \
+  --head production \
+  --base dev \
+  --title "chore: sync production into dev after vX.Y.Z release" \
+  --body "Syncs production back into dev after the [vX.Y.Z release](https://github.com/codercops/ogcops/releases/tag/vX.Y.Z)."
+```
+
+Then **merge** this PR (use regular merge, NOT squash, to keep history aligned).
+
+### 6. Update your fork
+
+```bash
+git fetch upstream
+git checkout dev
+git pull upstream dev
+git push origin dev
+```
+
+## Quick Reference (Copy-Paste)
+
+Replace `X.Y.Z` with the actual version and `PREVIOUS` with the last release tag.
+
+```bash
+# Step 1: Verify
+npm run check && npm run test && npm run build
+
+# Step 2: Release PR
+gh pr create --repo codercops/ogcops --head dev --base production \
+  --title "release: vX.Y.Z — Description"
+
+# Step 3: Merge the PR on GitHub (squash and merge)
+
+# Step 4: Create release
+gh release create vX.Y.Z --repo codercops/ogcops --target production \
+  --title "vX.Y.Z — Description" --generate-notes
+
+# Step 5: Sync PR
+gh pr create --repo codercops/ogcops --head production --base dev \
+  --title "chore: sync production into dev after vX.Y.Z release"
+
+# Step 6: Merge the sync PR on GitHub (regular merge, NOT squash)
+
+# Step 7: Update fork
+git fetch upstream && git checkout dev && git pull upstream dev && git push origin dev
+```
+
+## Notes
+
+- The `pr-target-check.yml` workflow enforces that only `dev` can PR into `production`.
+- CI runs on all PRs to both `dev` and `production` branches.
+- Vercel auto-deploys `production` after merge.
+- Use `--generate-notes` flag on `gh release create` to auto-generate changelog from commits.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,7 @@ The following are **out of scope:**
 
 | Version | Supported |
 |---------|-----------|
-| Latest (main branch) | Yes |
+| Latest (production branch) | Yes |
 | Older releases | No |
 
 ## Recognition

--- a/src/components/BackToTop.astro
+++ b/src/components/BackToTop.astro
@@ -31,7 +31,7 @@
 <style>
   .back-to-top {
     position: fixed;
-    bottom: 90px;
+    bottom: 80px;
     right: var(--space-xl, 24px);
     z-index: 8000;
     width: 40px;

--- a/src/components/FeedbackButton.astro
+++ b/src/components/FeedbackButton.astro
@@ -1,0 +1,58 @@
+<!-- Feedback button: fixed bottom-right, opens GitHub issues -->
+<a
+  href="https://github.com/codercops/ogcops/issues/new/choose"
+  target="_blank"
+  rel="noopener"
+  class="feedback-btn"
+  aria-label="Send feedback"
+  title="Send feedback"
+>
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+  </svg>
+  <span class="feedback-btn-label">Feedback</span>
+</a>
+
+<style>
+  .feedback-btn {
+    position: fixed;
+    bottom: var(--space-xl, 24px);
+    right: var(--space-xl, 24px);
+    z-index: 8000;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 14px;
+    background: var(--bg-elevated, #fff);
+    border: 1px solid var(--border, #e5e5e5);
+    border-radius: var(--radius-full, 999px);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    color: var(--text-muted, #666);
+    font-size: 12px;
+    font-weight: 500;
+    text-decoration: none;
+    cursor: pointer;
+    transition: color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+  }
+
+  .feedback-btn:hover {
+    color: var(--accent-primary, #e07a5f);
+    border-color: var(--accent-primary, #e07a5f);
+    box-shadow: 0 4px 12px rgba(224, 122, 95, 0.15);
+  }
+
+  .feedback-btn svg {
+    flex-shrink: 0;
+  }
+
+  @media (max-width: 480px) {
+    .feedback-btn {
+      right: var(--space-md, 12px);
+      padding: 8px 12px;
+    }
+
+    .feedback-btn-label {
+      display: none;
+    }
+  }
+</style>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -20,6 +20,7 @@ const year = new Date().getFullYear();
         <a href="/templates">Templates</a>
         <a href="/api-docs">API Docs</a>
         <a href="https://github.com/codercops/ogcops" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/codercops/ogcops/issues/new?labels=feedback&title=Feedback:&body=<!-- Describe your feedback here -->" target="_blank" rel="noopener">Feedback</a>
       </nav>
     </div>
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -36,41 +36,82 @@ const navItems = [
       </a>
     </div>
 
-    <button class="mobile-menu-btn" id="mobile-menu-btn" aria-label="Menu">
+    <button class="mobile-menu-btn" id="mobile-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">
       <span></span><span></span><span></span>
     </button>
   </nav>
+
+  <!-- Mobile menu lives inside <header> so it survives transition:persist -->
+  <div class="mobile-menu" id="mobile-menu">
+    <div class="mobile-menu-inner">
+      {navItems.map((item, i) => (
+        <a
+          href={item.href}
+          class:list={['mobile-menu-link', { 'mobile-link-active': currentPath === item.href || (item.href !== '/' && currentPath.startsWith(item.href)) }]}
+          style={`--delay: ${i * 50}ms`}
+        >
+          {item.label}
+        </a>
+      ))}
+      <a href="https://github.com/codercops/ogcops" target="_blank" rel="noopener" class="mobile-menu-link mobile-github-link" style={`--delay: ${navItems.length * 50}ms`}>
+        <svg class="github-icon" viewBox="0 0 16 16" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>
+        Star on GitHub
+        {starCount !== null && <span class="star-count">{formatStarCount(starCount)}</span>}
+      </a>
+    </div>
+  </div>
 </header>
 
-<!-- Mobile Menu -->
-<div class="mobile-menu" id="mobile-menu">
-  <div class="mobile-menu-inner">
-    {navItems.map((item, i) => (
-      <a href={item.href} class="mobile-menu-link" style={`--delay: ${i * 50}ms`}>{item.label}</a>
-    ))}
-    <a href="https://github.com/codercops/ogcops" target="_blank" rel="noopener" class="mobile-menu-link mobile-github-link" style={`--delay: ${navItems.length * 50}ms`}>
-      <svg class="github-icon" viewBox="0 0 16 16" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>
-      Star on GitHub
-      {starCount !== null && <span class="star-count">{formatStarCount(starCount)}</span>}
-    </a>
-  </div>
-</div>
-
 <script is:inline>
-  // Mobile menu
-  const menuBtn = document.getElementById('mobile-menu-btn');
-  const mobileMenu = document.getElementById('mobile-menu');
-  menuBtn?.addEventListener('click', () => {
-    menuBtn.classList.toggle('open');
-    mobileMenu?.classList.toggle('open');
-  });
+  (function() {
+    var menuBtn = document.getElementById('mobile-menu-btn');
+    var menu = document.getElementById('mobile-menu');
+    if (!menuBtn || !menu) return;
+
+    function openMenu() {
+      menuBtn.classList.add('open');
+      menuBtn.setAttribute('aria-expanded', 'true');
+      menu.classList.add('open');
+      document.body.style.overflow = 'hidden';
+    }
+
+    function closeMenu() {
+      menuBtn.classList.remove('open');
+      menuBtn.setAttribute('aria-expanded', 'false');
+      menu.classList.remove('open');
+      document.body.style.overflow = '';
+    }
+
+    menuBtn.addEventListener('click', function() {
+      if (menu.classList.contains('open')) {
+        closeMenu();
+      } else {
+        openMenu();
+      }
+    });
+
+    menu.addEventListener('click', function(e) {
+      if (e.target.closest('.mobile-menu-link')) {
+        closeMenu();
+      } else if (e.target === menu || !e.target.closest('.mobile-menu-inner')) {
+        closeMenu();
+      }
+    });
+
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape' && menu.classList.contains('open')) {
+        closeMenu();
+      }
+    });
+  })();
 </script>
 
 <style>
+  /* ===== Header bar ===== */
   .header {
     position: sticky;
     top: 0;
-    z-index: 100;
+    z-index: 500;
     background: var(--bg-frosted);
     backdrop-filter: saturate(180%) blur(20px);
     -webkit-backdrop-filter: saturate(180%) blur(20px);
@@ -108,7 +149,6 @@ const navItems = [
   }
 
   .logo-fallback { display: none; }
-
   .logo-text { color: var(--text); }
   .logo-accent { color: var(--accent-primary); }
 
@@ -127,6 +167,7 @@ const navItems = [
     line-height: 1.4;
   }
 
+  /* ===== Desktop links ===== */
   .header-links {
     display: flex;
     align-items: center;
@@ -183,18 +224,32 @@ const navItems = [
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
   }
 
+  /* ===== Hamburger button ===== */
   .mobile-menu-btn {
     display: none;
     flex-direction: column;
-    gap: 4px;
-    width: 36px;
-    height: 36px;
+    gap: 5px;
+    width: 44px;
+    height: 44px;
     align-items: center;
     justify-content: center;
     border: none;
     background: none;
     cursor: pointer;
-    padding: 8px;
+    padding: 0;
+    margin-left: auto;
+    -webkit-tap-highlight-color: transparent;
+    border-radius: var(--radius);
+    transition: background-color var(--transition);
+    flex-shrink: 0;
+    position: relative;
+    z-index: 210;
+    touch-action: manipulation;
+  }
+
+  .mobile-menu-btn:hover,
+  .mobile-menu-btn:active {
+    background-color: var(--bg-surface);
   }
 
   .mobile-menu-btn span {
@@ -202,42 +257,109 @@ const navItems = [
     width: 20px;
     height: 2px;
     background: var(--text);
-    transition: transform var(--transition), opacity var(--transition);
+    border-radius: 1px;
+    transform-origin: center;
+    transition: transform 0.3s var(--ease-out), opacity 0.2s var(--ease-out);
   }
 
-  .mobile-menu-btn.open span:nth-child(1) { transform: rotate(45deg) translate(4px, 4px); }
-  .mobile-menu-btn.open span:nth-child(2) { opacity: 0; }
-  .mobile-menu-btn.open span:nth-child(3) { transform: rotate(-45deg) translate(4px, -4px); }
-
-  .mobile-menu {
-    display: none;
-    position: fixed;
-    inset: var(--nav-height) 0 0 0;
-    background: var(--bg-frosted);
-    backdrop-filter: saturate(180%) blur(20px);
-    -webkit-backdrop-filter: saturate(180%) blur(20px);
-    z-index: 99;
-    padding: var(--space-xl);
+  .mobile-menu-btn.open span:nth-child(1) {
+    transform: translateY(7px) rotate(45deg);
+  }
+  .mobile-menu-btn.open span:nth-child(2) {
     opacity: 0;
-    transform: translateY(-8px);
-    transition: opacity var(--transition), transform var(--transition);
+    transform: scaleX(0);
+  }
+  .mobile-menu-btn.open span:nth-child(3) {
+    transform: translateY(-7px) rotate(-45deg);
+  }
+
+  /* ===== Mobile menu overlay ===== */
+  .mobile-menu {
+    position: fixed;
+    left: 0;
+    right: 0;
+    top: var(--nav-height);
+    bottom: 0;
+    z-index: 200;
+    visibility: hidden;
+    pointer-events: none;
   }
 
   .mobile-menu.open {
-    opacity: 1;
-    transform: translateY(0);
+    visibility: visible;
+    pointer-events: auto;
   }
 
+  /* Backdrop dim */
+  .mobile-menu::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.2);
+    opacity: 0;
+    transition: opacity 0.3s var(--ease-out);
+  }
+
+  .mobile-menu.open::before {
+    opacity: 1;
+  }
+
+  .mobile-menu-inner {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-frosted);
+    backdrop-filter: saturate(180%) blur(24px);
+    -webkit-backdrop-filter: saturate(180%) blur(24px);
+    border-bottom: 1px solid var(--border);
+    box-shadow: var(--shadow-lg);
+    padding: var(--space-sm) var(--space-xl);
+    padding-bottom: max(var(--space-lg), env(safe-area-inset-bottom));
+    max-height: calc(100vh - var(--nav-height));
+    max-height: calc(100dvh - var(--nav-height));
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    transform: translateY(-12px);
+    opacity: 0;
+    transition: transform 0.3s var(--ease-out), opacity 0.25s var(--ease-out);
+  }
+
+  .mobile-menu.open .mobile-menu-inner {
+    transform: translateY(0);
+    opacity: 1;
+  }
+
+  /* ===== Mobile menu links ===== */
   .mobile-menu-link {
-    display: block;
-    padding: var(--space-md) 0;
-    font-size: var(--text-lg);
+    display: flex;
+    align-items: center;
+    padding: var(--space-lg) var(--space-sm);
+    font-size: var(--text-base);
     font-weight: 500;
     color: var(--text);
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid var(--border-muted);
+    min-height: 52px;
+    -webkit-tap-highlight-color: transparent;
+    border-radius: var(--radius);
+    transition: background-color 0.15s ease, color 0.15s ease;
     opacity: 0;
-    transform: translateY(-4px);
-    transition: opacity 0.3s ease var(--delay, 0ms), transform 0.3s ease var(--delay, 0ms);
+    transform: translateY(-6px);
+    transition: opacity 0.3s ease var(--delay, 0ms),
+                transform 0.3s ease var(--delay, 0ms),
+                background-color 0.15s ease;
+  }
+
+  .mobile-menu-link:last-child {
+    border-bottom: none;
+  }
+
+  .mobile-menu-link:active {
+    background-color: var(--bg-surface);
+  }
+
+  .mobile-menu-link.mobile-link-active {
+    color: var(--accent-primary);
+    font-weight: 600;
   }
 
   .mobile-menu.open .mobile-menu-link {
@@ -249,21 +371,64 @@ const navItems = [
     display: flex;
     align-items: center;
     gap: var(--space-sm);
+    margin-top: var(--space-xs);
+    padding-top: var(--space-lg);
+    border-top: 1px solid var(--border);
+    border-bottom: none;
   }
 
   .mobile-github-link .star-count {
     margin-left: auto;
-    padding: 2px 8px;
+    padding: 3px 10px;
     background: var(--bg-surface);
     border: 1px solid var(--border);
     border-radius: var(--radius-sm);
     font-size: var(--text-xs);
   }
 
+  /* ===== Mobile breakpoints ===== */
   @media (max-width: 768px) {
     .header-links { display: none; }
     .mobile-menu-btn { display: flex; }
-    .mobile-menu { display: block; }
     .oss-badge { display: none; }
+
+    .header-nav {
+      height: var(--nav-height);
+      padding: 0 var(--space-md);
+      gap: var(--space-md);
+    }
+
+    .mobile-menu {
+      top: var(--nav-height);
+    }
+
+    .logo-img {
+      height: 24px;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .header-nav {
+      height: var(--nav-height);
+      padding: 0 var(--space-sm);
+    }
+
+    .mobile-menu-inner {
+      padding-left: var(--space-md);
+      padding-right: var(--space-md);
+    }
+
+    .logo-img {
+      height: 22px;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .mobile-menu-inner,
+    .mobile-menu-link,
+    .mobile-menu-btn span,
+    .mobile-menu::before {
+      transition-duration: 0.01ms !important;
+    }
   }
 </style>

--- a/src/components/editor/AIAutofill.tsx
+++ b/src/components/editor/AIAutofill.tsx
@@ -1,0 +1,149 @@
+import { useState, useCallback } from 'react';
+import { useAI } from './AIContext';
+import { getApiKey, getSelectedProvider, getSelectedModel } from '@/lib/ai/storage';
+import { getDefaultModel } from '@/lib/ai/providers';
+
+interface AIAutofillProps {
+  onAutofill: (result: { templateId: string; fields: Record<string, string>; colors?: Record<string, string> }) => void;
+}
+
+type Step = 'idle' | 'fetching' | 'analyzing' | 'generating' | 'done' | 'error';
+
+export function AIAutofill({ onAutofill }: AIAutofillProps) {
+  const { isConfigured, openSettings } = useAI();
+  const [url, setUrl] = useState('');
+  const [step, setStep] = useState<Step>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(false);
+
+  const handleAutofill = useCallback(async () => {
+    if (!url.trim()) return;
+
+    if (!isConfigured) {
+      openSettings();
+      return;
+    }
+
+    const provider = getSelectedProvider();
+    const apiKey = provider ? getApiKey(provider) : null;
+    const model = provider ? (getSelectedModel(provider) ?? getDefaultModel(provider)) : null;
+
+    if (!provider || !apiKey || !model) {
+      openSettings();
+      return;
+    }
+
+    setError(null);
+    setStep('fetching');
+
+    try {
+      setStep('analyzing');
+
+      const res = await fetch('/api/ai/autofill', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          provider,
+          apiKey,
+          model,
+          url: url.trim().startsWith('http') ? url.trim() : `https://${url.trim()}`,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({ error: 'Autofill failed' }));
+        throw new Error(data.error || `HTTP ${res.status}`);
+      }
+
+      setStep('generating');
+      const result = await res.json();
+
+      onAutofill(result);
+      setStep('done');
+      setTimeout(() => {
+        setStep('idle');
+        setExpanded(false);
+      }, 1500);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Autofill failed');
+      setStep('error');
+    }
+  }, [url, isConfigured, openSettings, onAutofill]);
+
+  if (!expanded) {
+    return (
+      <button
+        type="button"
+        className="ai-autofill-trigger"
+        onClick={() => setExpanded(true)}
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M12 3l1.912 5.813a2 2 0 0 0 1.275 1.275L21 12l-5.813 1.912a2 2 0 0 0-1.275 1.275L12 21l-1.912-5.813a2 2 0 0 0-1.275-1.275L3 12l5.813-1.912a2 2 0 0 0 1.275-1.275L12 3z" />
+        </svg>
+        Smart Autofill
+      </button>
+    );
+  }
+
+  return (
+    <div className="ai-autofill">
+      <div className="ai-autofill-header">
+        <span className="ai-autofill-title">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 3l1.912 5.813a2 2 0 0 0 1.275 1.275L21 12l-5.813 1.912a2 2 0 0 0-1.275 1.275L12 21l-1.912-5.813a2 2 0 0 0-1.275-1.275L3 12l5.813-1.912a2 2 0 0 0 1.275-1.275L12 3z" />
+          </svg>
+          Smart Autofill
+        </span>
+        <button type="button" className="ai-autofill-close" onClick={() => { setExpanded(false); setStep('idle'); setError(null); }}>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      </div>
+      <p className="ai-autofill-desc">Paste a URL and we'll generate your OG image automatically.</p>
+      <div className="ai-autofill-input-row">
+        <input
+          type="url"
+          className="ai-autofill-input"
+          placeholder="https://example.com/blog-post"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') handleAutofill(); }}
+          disabled={step !== 'idle' && step !== 'error'}
+        />
+        <button
+          type="button"
+          className="ai-btn ai-btn-validate"
+          onClick={handleAutofill}
+          disabled={!url.trim() || (step !== 'idle' && step !== 'error')}
+          style={{ flexShrink: 0 }}
+        >
+          {step === 'idle' || step === 'error' ? 'Generate' : 'Working...'}
+        </button>
+      </div>
+
+      {(step !== 'idle' && step !== 'error') && (
+        <div className="ai-autofill-steps">
+          <div className={`ai-autofill-step ${step === 'fetching' || step === 'analyzing' || step === 'generating' || step === 'done' ? 'done' : ''}`}>
+            {step === 'fetching' ? <span className="ai-spinner-dark" /> : '✓'} Fetching page content
+          </div>
+          <div className={`ai-autofill-step ${step === 'analyzing' || step === 'generating' || step === 'done' ? 'active' : ''} ${step === 'generating' || step === 'done' ? 'done' : ''}`}>
+            {step === 'analyzing' ? <span className="ai-spinner-dark" /> : step === 'generating' || step === 'done' ? '✓' : '○'} Selecting best template
+          </div>
+          <div className={`ai-autofill-step ${step === 'generating' || step === 'done' ? 'active' : ''} ${step === 'done' ? 'done' : ''}`}>
+            {step === 'generating' ? <span className="ai-spinner-dark" /> : step === 'done' ? '✓' : '○'} Generating content
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <div className="ai-status ai-status-error" style={{ marginTop: '8px' }}>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="12" r="10" /><line x1="15" y1="9" x2="9" y2="15" /><line x1="9" y1="9" x2="15" y2="15" />
+          </svg>
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/editor/AIContext.tsx
+++ b/src/components/editor/AIContext.tsx
@@ -1,0 +1,116 @@
+import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from 'react';
+import type { AIProvider } from '@/lib/ai/types';
+import {
+  getApiKey,
+  getSelectedProvider,
+  getSelectedModel,
+  hasAnyKeyConfigured,
+  setSelectedProvider as storeProvider,
+  setSelectedModel as storeModel,
+} from '@/lib/ai/storage';
+import { getDefaultModel } from '@/lib/ai/providers';
+
+interface AIContextValue {
+  /** Whether any provider has a saved key */
+  isConfigured: boolean;
+  /** Currently selected provider */
+  provider: AIProvider | null;
+  /** Currently selected model */
+  model: string | null;
+  /** Open the AI settings modal */
+  openSettings: () => void;
+  /** Close the AI settings modal */
+  closeSettings: () => void;
+  /** Whether the settings modal is open */
+  settingsOpen: boolean;
+  /** Call the AI generate endpoint */
+  generate: (prompt: string, systemPrompt?: string) => Promise<string>;
+  /** Refresh state from localStorage (call after settings change) */
+  refresh: () => void;
+}
+
+const AICtx = createContext<AIContextValue | null>(null);
+
+export function AIProvider({ children }: { children: ReactNode }) {
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [isConfigured, setIsConfigured] = useState(false);
+  const [provider, setProvider] = useState<AIProvider | null>(null);
+  const [model, setModel] = useState<string | null>(null);
+
+  const refresh = useCallback(() => {
+    setIsConfigured(hasAnyKeyConfigured());
+    const p = getSelectedProvider();
+    setProvider(p);
+    setModel(p ? getSelectedModel(p) ?? getDefaultModel(p) ?? null : null);
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const openSettings = useCallback(() => setSettingsOpen(true), []);
+  const closeSettings = useCallback(() => {
+    setSettingsOpen(false);
+    refresh();
+  }, [refresh]);
+
+  const generate = useCallback(
+    async (prompt: string, systemPrompt?: string): Promise<string> => {
+      const currentProvider = getSelectedProvider();
+      if (!currentProvider) throw new Error('No AI provider configured');
+
+      const apiKey = getApiKey(currentProvider);
+      if (!apiKey) throw new Error('No API key configured');
+
+      const currentModel =
+        getSelectedModel(currentProvider) ?? getDefaultModel(currentProvider);
+      if (!currentModel) throw new Error('No model selected');
+
+      const res = await fetch('/api/ai/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          provider: currentProvider,
+          apiKey,
+          model: currentModel,
+          prompt,
+          systemPrompt,
+          maxTokens: 300,
+          temperature: 0.8,
+        }),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: 'Generation failed' }));
+        throw new Error(err.error || `HTTP ${res.status}`);
+      }
+
+      const data = await res.json();
+      return data.content;
+    },
+    []
+  );
+
+  return (
+    <AICtx.Provider
+      value={{
+        isConfigured,
+        provider,
+        model,
+        openSettings,
+        closeSettings,
+        settingsOpen,
+        generate,
+        refresh,
+      }}
+    >
+      {children}
+    </AICtx.Provider>
+  );
+}
+
+export function useAI(): AIContextValue {
+  const ctx = useContext(AICtx);
+  if (!ctx) throw new Error('useAI must be used within <AIProvider>');
+  return ctx;
+}

--- a/src/components/editor/AIGenerateButton.tsx
+++ b/src/components/editor/AIGenerateButton.tsx
@@ -1,0 +1,98 @@
+import { useState, useCallback } from 'react';
+import { useAI } from './AIContext';
+import { generateSuggestions } from '@/lib/ai/generate';
+import { AISuggestionPicker } from './AISuggestionPicker';
+import type { GenerateContext } from '@/lib/ai/prompts';
+
+interface AIGenerateButtonProps {
+  fieldName: string;
+  category?: string;
+  currentValues?: Record<string, string>;
+  onSelect: (value: string) => void;
+}
+
+export function AIGenerateButton({ fieldName, category, currentValues, onSelect }: AIGenerateButtonProps) {
+  const { isConfigured, openSettings } = useAI();
+  const [showPicker, setShowPicker] = useState(false);
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const doGenerate = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setSuggestions([]);
+    setShowPicker(true);
+
+    const ctx: GenerateContext = {
+      fieldName,
+      category,
+      currentValues,
+      count: 3,
+    };
+
+    try {
+      const results = await generateSuggestions(ctx);
+      setSuggestions(results);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Generation failed');
+      setShowPicker(false);
+    } finally {
+      setLoading(false);
+    }
+  }, [fieldName, category, currentValues]);
+
+  const handleClick = useCallback(() => {
+    if (!isConfigured) {
+      openSettings();
+      return;
+    }
+    doGenerate();
+  }, [isConfigured, openSettings, doGenerate]);
+
+  const handleSelect = useCallback(
+    (value: string) => {
+      onSelect(value);
+      setShowPicker(false);
+    },
+    [onSelect]
+  );
+
+  const handleClose = useCallback(() => {
+    setShowPicker(false);
+  }, []);
+
+  return (
+    <div className="ai-generate-wrapper">
+      <button
+        type="button"
+        className={`ai-generate-btn ${error ? 'error' : ''}`}
+        onClick={handleClick}
+        title={isConfigured ? `Generate ${fieldName} with AI` : 'Set up AI to generate suggestions'}
+      >
+        {loading ? (
+          <span className="ai-spinner-dark" />
+        ) : (
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 3l1.912 5.813a2 2 0 0 0 1.275 1.275L21 12l-5.813 1.912a2 2 0 0 0-1.275 1.275L12 21l-1.912-5.813a2 2 0 0 0-1.275-1.275L3 12l5.813-1.912a2 2 0 0 0 1.275-1.275L12 3z" />
+          </svg>
+        )}
+        AI
+      </button>
+      {showPicker && (
+        <AISuggestionPicker
+          suggestions={suggestions}
+          onSelect={handleSelect}
+          onRegenerate={doGenerate}
+          onClose={handleClose}
+          loading={loading}
+        />
+      )}
+      {error && !showPicker && (
+        <div className="ai-generate-error" title={error}>
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/editor/AISettingsModal.tsx
+++ b/src/components/editor/AISettingsModal.tsx
@@ -1,0 +1,293 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { AIProvider as AIProviderType } from '@/lib/ai/types';
+import { AI_PROVIDERS } from '@/lib/ai/types';
+import { getAllProviders, getModelsForProvider, getDefaultModel } from '@/lib/ai/providers';
+import {
+  getApiKey,
+  setApiKey,
+  removeApiKey,
+  getSelectedProvider,
+  setSelectedProvider,
+  getSelectedModel,
+  setSelectedModel,
+} from '@/lib/ai/storage';
+
+interface AISettingsModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+type ValidationStatus = 'idle' | 'validating' | 'valid' | 'invalid' | 'error';
+
+const PROVIDERS = getAllProviders();
+
+export function AISettingsModal({ open, onClose }: AISettingsModalProps) {
+  const [activeProvider, setActiveProvider] = useState<AIProviderType>(() => getSelectedProvider() ?? 'openai');
+  const [keyValue, setKeyValue] = useState('');
+  const [showKey, setShowKey] = useState(false);
+  const [selectedModel, setModelLocal] = useState('');
+  const [status, setStatus] = useState<ValidationStatus>('idle');
+  const [statusMessage, setStatusMessage] = useState('');
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Load stored values when provider changes
+  useEffect(() => {
+    const storedKey = getApiKey(activeProvider) ?? '';
+    setKeyValue(storedKey);
+    setShowKey(false);
+    const storedModel = getSelectedModel(activeProvider) ?? getDefaultModel(activeProvider) ?? '';
+    setModelLocal(storedModel);
+    setStatus(storedKey ? 'idle' : 'idle');
+    setStatusMessage('');
+  }, [activeProvider]);
+
+  // Focus input on open
+  useEffect(() => {
+    if (open) {
+      setTimeout(() => inputRef.current?.focus(), 100);
+    }
+  }, [open]);
+
+  // ESC to close
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open, onClose]);
+
+  const handleProviderChange = useCallback((id: AIProviderType) => {
+    setActiveProvider(id);
+    setSelectedProvider(id);
+  }, []);
+
+  const handleKeyChange = useCallback(
+    (value: string) => {
+      const trimmed = value.trim();
+      setKeyValue(trimmed);
+      setStatus('idle');
+      setStatusMessage('');
+      // Auto-save as user types
+      if (trimmed) {
+        setApiKey(activeProvider, trimmed);
+      }
+    },
+    [activeProvider]
+  );
+
+  const handleModelChange = useCallback(
+    (modelId: string) => {
+      setModelLocal(modelId);
+      setSelectedModel(activeProvider, modelId);
+    },
+    [activeProvider]
+  );
+
+  const handleValidate = useCallback(async () => {
+    if (!keyValue) return;
+    setStatus('validating');
+    setStatusMessage('');
+
+    try {
+      const res = await fetch('/api/ai/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider: activeProvider, apiKey: keyValue }),
+      });
+
+      const data = await res.json();
+      if (data.valid) {
+        setStatus('valid');
+        setStatusMessage('Key is valid — ready to use');
+      } else {
+        setStatus('invalid');
+        setStatusMessage(data.error || 'Invalid API key');
+      }
+    } catch {
+      setStatus('error');
+      setStatusMessage('Could not reach validation endpoint');
+    }
+  }, [activeProvider, keyValue]);
+
+  const handleClear = useCallback(() => {
+    removeApiKey(activeProvider);
+    setKeyValue('');
+    setStatus('idle');
+    setStatusMessage('');
+    setShowKey(false);
+  }, [activeProvider]);
+
+  const handleOverlayClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === overlayRef.current) onClose();
+    },
+    [onClose]
+  );
+
+  if (!open) return null;
+
+  const providerConfig = PROVIDERS.find((p) => p.id === activeProvider)!;
+  const models = getModelsForProvider(activeProvider);
+
+  return (
+    <div className="ai-modal-overlay" ref={overlayRef} onClick={handleOverlayClick}>
+      <div className="ai-modal" role="dialog" aria-label="AI Settings">
+        {/* Header */}
+        <div className="ai-modal-header">
+          <h3 className="ai-modal-title">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--accent-primary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M12 3l1.912 5.813a2 2 0 0 0 1.275 1.275L21 12l-5.813 1.912a2 2 0 0 0-1.275 1.275L12 21l-1.912-5.813a2 2 0 0 0-1.275-1.275L3 12l5.813-1.912a2 2 0 0 0 1.275-1.275L12 3z" />
+            </svg>
+            AI Settings
+          </h3>
+          <button type="button" className="ai-modal-close" onClick={onClose} aria-label="Close">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="ai-modal-body">
+          {/* Provider Selection */}
+          <div className="ai-field">
+            <label className="ai-field-label">Provider</label>
+            <div className="ai-provider-grid">
+              {PROVIDERS.map((p) => (
+                <button
+                  key={p.id}
+                  type="button"
+                  className={`ai-provider-btn ${activeProvider === p.id ? 'active' : ''}`}
+                  onClick={() => handleProviderChange(p.id)}
+                >
+                  {p.name}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* API Key */}
+          <div className="ai-field">
+            <label className="ai-field-label" htmlFor="ai-key-input">API Key</label>
+            <div className="ai-key-row">
+              <input
+                ref={inputRef}
+                id="ai-key-input"
+                type={showKey ? 'text' : 'password'}
+                className="ai-key-input"
+                value={keyValue}
+                onChange={(e) => handleKeyChange(e.target.value)}
+                placeholder={`Paste your ${providerConfig.name} API key`}
+                autoComplete="off"
+                spellCheck={false}
+              />
+              <button
+                type="button"
+                className="ai-key-toggle"
+                onClick={() => setShowKey(!showKey)}
+                aria-label={showKey ? 'Hide key' : 'Show key'}
+                title={showKey ? 'Hide key' : 'Show key'}
+              >
+                {showKey ? (
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+                    <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+                    <line x1="1" y1="1" x2="23" y2="23" />
+                  </svg>
+                ) : (
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                    <circle cx="12" cy="12" r="3" />
+                  </svg>
+                )}
+              </button>
+            </div>
+            <a
+              href={providerConfig.apiKeyUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ai-key-link"
+            >
+              Get your {providerConfig.name} API key
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" /><polyline points="15 3 21 3 21 9" /><line x1="10" y1="14" x2="21" y2="3" />
+              </svg>
+            </a>
+          </div>
+
+          {/* Model */}
+          <div className="ai-field">
+            <label className="ai-field-label" htmlFor="ai-model-select">Model</label>
+            <select
+              id="ai-model-select"
+              className="ai-model-select"
+              value={selectedModel}
+              onChange={(e) => handleModelChange(e.target.value)}
+            >
+              {models.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.name} — {m.description}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Actions */}
+          <div className="ai-actions">
+            <button
+              type="button"
+              className="ai-btn ai-btn-validate"
+              onClick={handleValidate}
+              disabled={!keyValue || status === 'validating'}
+            >
+              {status === 'validating' ? (
+                <>
+                  <span className="ai-spinner" />
+                  Validating...
+                </>
+              ) : (
+                'Validate Key'
+              )}
+            </button>
+            <button
+              type="button"
+              className="ai-btn ai-btn-clear"
+              onClick={handleClear}
+              disabled={!keyValue}
+            >
+              Clear Key
+            </button>
+          </div>
+
+          {/* Status */}
+          {statusMessage && (
+            <div className={`ai-status ai-status-${status}`}>
+              {status === 'valid' && (
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+              )}
+              {(status === 'invalid' || status === 'error') && (
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="12" cy="12" r="10" /><line x1="15" y1="9" x2="9" y2="15" /><line x1="9" y1="9" x2="15" y2="15" />
+                </svg>
+              )}
+              {statusMessage}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="ai-modal-footer">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="3" y="11" width="18" height="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" />
+          </svg>
+          Your API key is stored locally in your browser. It is never stored on our servers.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/editor/AISuggestionPicker.tsx
+++ b/src/components/editor/AISuggestionPicker.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface AISuggestionPickerProps {
+  suggestions: string[];
+  onSelect: (value: string) => void;
+  onRegenerate: () => void;
+  onClose: () => void;
+  loading?: boolean;
+}
+
+export function AISuggestionPicker({
+  suggestions,
+  onSelect,
+  onRegenerate,
+  onClose,
+  loading,
+}: AISuggestionPickerProps) {
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Click outside to close
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [onClose]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActiveIndex((i) => (i < suggestions.length - 1 ? i + 1 : 0));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActiveIndex((i) => (i > 0 ? i - 1 : suggestions.length - 1));
+      } else if (e.key === 'Enter' && activeIndex >= 0) {
+        e.preventDefault();
+        onSelect(suggestions[activeIndex]);
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [activeIndex, suggestions, onSelect, onClose]);
+
+  return (
+    <div className="ai-picker" ref={containerRef}>
+      <div className="ai-picker-header">
+        <span className="ai-picker-title">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 3l1.912 5.813a2 2 0 0 0 1.275 1.275L21 12l-5.813 1.912a2 2 0 0 0-1.275 1.275L12 21l-1.912-5.813a2 2 0 0 0-1.275-1.275L3 12l5.813-1.912a2 2 0 0 0 1.275-1.275L12 3z" />
+          </svg>
+          Pick a suggestion
+        </span>
+      </div>
+      <div className="ai-picker-list">
+        {loading ? (
+          <div className="ai-picker-loading">
+            <span className="ai-spinner-dark" />
+            Generating...
+          </div>
+        ) : (
+          suggestions.map((s, i) => (
+            <button
+              key={i}
+              type="button"
+              className={`ai-picker-option ${activeIndex === i ? 'active' : ''}`}
+              onClick={() => onSelect(s)}
+              onMouseEnter={() => setActiveIndex(i)}
+            >
+              {s}
+            </button>
+          ))
+        )}
+      </div>
+      <div className="ai-picker-footer">
+        <button
+          type="button"
+          className="ai-picker-btn"
+          onClick={onRegenerate}
+          disabled={loading}
+        >
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="23 4 23 10 17 10" /><polyline points="1 20 1 14 7 14" />
+            <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+          </svg>
+          Regenerate
+        </button>
+        <button
+          type="button"
+          className="ai-picker-btn"
+          onClick={onClose}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/editor/AITemplateSearch.tsx
+++ b/src/components/editor/AITemplateSearch.tsx
@@ -1,0 +1,143 @@
+import { useState, useCallback, useRef } from 'react';
+import type { TemplateDefinition } from '@/templates/types';
+import { getApiKey, getSelectedProvider, getSelectedModel, hasAnyKeyConfigured } from '@/lib/ai/storage';
+import { getDefaultModel } from '@/lib/ai/providers';
+import { buildRecommenderPrompt, parseRecommenderResponse, type TemplateRecommendation } from '@/lib/ai/recommender';
+
+interface AITemplateSearchProps {
+  templates: TemplateDefinition[];
+  onTemplateSelect: (template: TemplateDefinition) => void;
+}
+
+export function AITemplateSearch({ templates, onTemplateSelect }: AITemplateSearchProps) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<(TemplateRecommendation & { template: TemplateDefinition })[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const isConfigured = hasAnyKeyConfigured();
+
+  const doSearch = useCallback(async (searchQuery: string) => {
+    if (!searchQuery.trim() || searchQuery.trim().length < 3) {
+      setResults([]);
+      return;
+    }
+
+    const provider = getSelectedProvider();
+    const apiKey = provider ? getApiKey(provider) : null;
+    const model = provider ? (getSelectedModel(provider) ?? getDefaultModel(provider)) : null;
+
+    if (!provider || !apiKey || !model) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const { prompt, systemPrompt } = buildRecommenderPrompt(searchQuery);
+
+      const res = await fetch('/api/ai/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          provider,
+          apiKey,
+          model,
+          prompt,
+          systemPrompt,
+          maxTokens: 400,
+          temperature: 0.3,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({ error: 'Search failed' }));
+        throw new Error(data.error || `HTTP ${res.status}`);
+      }
+
+      const data = await res.json();
+      const recommendations = parseRecommenderResponse(data.content);
+
+      // Match recommendations to actual templates
+      const matched = recommendations
+        .map((rec) => {
+          const template = templates.find((t) => t.id === rec.id);
+          return template ? { ...rec, template } : null;
+        })
+        .filter((r): r is NonNullable<typeof r> => r !== null);
+
+      setResults(matched);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Search failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [templates]);
+
+  const handleInputChange = useCallback((value: string) => {
+    setQuery(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!value.trim()) {
+      setResults([]);
+      return;
+    }
+    // Don't auto-search — wait for Enter
+  }, []);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      doSearch(query);
+    }
+  }, [query, doSearch]);
+
+  if (!isConfigured) return null;
+
+  return (
+    <div className="ai-template-search">
+      <div className="ai-template-search-row">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="ai-template-search-icon">
+          <path d="M12 3l1.912 5.813a2 2 0 0 0 1.275 1.275L21 12l-5.813 1.912a2 2 0 0 0-1.275 1.275L12 21l-1.912-5.813a2 2 0 0 0-1.275-1.275L3 12l5.813-1.912a2 2 0 0 0 1.275-1.275L12 3z" />
+        </svg>
+        <input
+          type="text"
+          className="ai-template-search-input"
+          placeholder="Describe your OG image... (Enter to search)"
+          value={query}
+          onChange={(e) => handleInputChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+        {loading && <span className="ai-spinner-dark" />}
+      </div>
+
+      {error && (
+        <div className="ai-template-search-error">{error}</div>
+      )}
+
+      {results.length > 0 && (
+        <div className="ai-template-search-results">
+          {results.map((r) => (
+            <button
+              key={r.id}
+              type="button"
+              className="ai-template-search-result"
+              onClick={() => onTemplateSelect(r.template)}
+            >
+              <img
+                src={`/api/templates/${r.id}/thumbnail.png`}
+                alt={r.template.name}
+                className="ai-template-search-thumb"
+                loading="lazy"
+              />
+              <div className="ai-template-search-info">
+                <span className="ai-template-search-name">{r.template.name}</span>
+                <span className="ai-template-search-reason">{r.reason}</span>
+                <span className="ai-template-search-score">{r.score}% match</span>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/editor/CustomizePanel.tsx
+++ b/src/components/editor/CustomizePanel.tsx
@@ -1,19 +1,23 @@
-import type { TemplateField } from '@/templates/types';
+import { useMemo, type ReactNode } from 'react';
+import type { TemplateField, TemplateCategory } from '@/templates/types';
 import { TextInput } from './TextInput';
 import { ColorPicker } from './ColorPicker';
 import { SliderControl } from './SliderControl';
 import { ToggleSwitch } from './ToggleSwitch';
 import { FontSelector } from './FontSelector';
 import { ImageUploader } from './ImageUploader';
+import { AIGenerateButton } from './AIGenerateButton';
 
 interface CustomizePanelProps {
   fields: TemplateField[];
   params: Record<string, any>;
   onParamChange: (key: string, value: any) => void;
   onReset: () => void;
+  category?: TemplateCategory;
+  autofill?: ReactNode;
 }
 
-export function CustomizePanel({ fields, params, onParamChange, onReset }: CustomizePanelProps) {
+export function CustomizePanel({ fields, params, onParamChange, onReset, category, autofill }: CustomizePanelProps) {
   // Group fields
   const groups: Record<string, TemplateField[]> = {};
   for (const field of fields) {
@@ -25,6 +29,15 @@ export function CustomizePanel({ fields, params, onParamChange, onReset }: Custo
   const groupOrder = ['Content', 'Style', 'Brand'];
   const sortedGroups = groupOrder.filter((g) => groups[g]).map((g) => [g, groups[g]] as const);
 
+  // Build string values map for AI context
+  const currentValues = useMemo(() => {
+    const vals: Record<string, string> = {};
+    for (const [k, v] of Object.entries(params)) {
+      if (typeof v === 'string' && v.trim()) vals[k] = v;
+    }
+    return vals;
+  }, [params]);
+
   return (
     <div className="customize-panel">
       <div className="customize-header">
@@ -33,11 +46,14 @@ export function CustomizePanel({ fields, params, onParamChange, onReset }: Custo
           Reset
         </button>
       </div>
+      {autofill}
       <div className="customize-fields">
         {sortedGroups.map(([groupName, groupFields]) => (
           <div key={groupName} className="customize-group">
             <h4 className="customize-group-title">{groupName}</h4>
-            {groupFields.map((field) => renderField(field, params[field.key] ?? field.defaultValue, onParamChange))}
+            {groupFields.map((field) =>
+              renderField(field, params[field.key] ?? field.defaultValue, onParamChange, category, currentValues)
+            )}
           </div>
         ))}
       </div>
@@ -45,7 +61,13 @@ export function CustomizePanel({ fields, params, onParamChange, onReset }: Custo
   );
 }
 
-function renderField(field: TemplateField, value: any, onChange: (key: string, value: any) => void) {
+function renderField(
+  field: TemplateField,
+  value: any,
+  onChange: (key: string, value: any) => void,
+  category?: TemplateCategory,
+  currentValues?: Record<string, string>
+) {
   switch (field.type) {
     case 'text':
       return (
@@ -56,6 +78,14 @@ function renderField(field: TemplateField, value: any, onChange: (key: string, v
           onChange={(v) => onChange(field.key, v)}
           placeholder={field.placeholder}
           required={field.required}
+          action={
+            <AIGenerateButton
+              fieldName={field.label}
+              category={category}
+              currentValues={currentValues}
+              onSelect={(v) => onChange(field.key, v)}
+            />
+          }
         />
       );
     case 'textarea':
@@ -68,6 +98,14 @@ function renderField(field: TemplateField, value: any, onChange: (key: string, v
           placeholder={field.placeholder}
           required={field.required}
           multiline
+          action={
+            <AIGenerateButton
+              fieldName={field.label}
+              category={category}
+              currentValues={currentValues}
+              onSelect={(v) => onChange(field.key, v)}
+            />
+          }
         />
       );
     case 'color':

--- a/src/components/editor/EditorApp.tsx
+++ b/src/components/editor/EditorApp.tsx
@@ -10,12 +10,45 @@ import { CustomizePanel } from './CustomizePanel';
 import { ExportBar } from './ExportBar';
 import { PlatformPreviewStrip } from './PlatformPreviewStrip';
 import { MobileEditorTabs } from './MobileEditorTabs';
+import { AIProvider, useAI } from './AIContext';
+import { AISettingsModal } from './AISettingsModal';
+import { AIAutofill } from './AIAutofill';
 
 interface EditorAppProps {
   initialCategory?: TemplateCategory;
 }
 
 export function EditorApp({ initialCategory }: EditorAppProps) {
+  return (
+    <AIProvider>
+      <EditorAppInner initialCategory={initialCategory} />
+    </AIProvider>
+  );
+}
+
+function AITopbarButton() {
+  const { isConfigured, openSettings } = useAI();
+  return (
+    <button
+      type="button"
+      className={`ai-topbar-btn ${isConfigured ? 'configured' : ''}`}
+      onClick={openSettings}
+      title={isConfigured ? 'AI Settings' : 'Set up AI'}
+    >
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 3l1.912 5.813a2 2 0 0 0 1.275 1.275L21 12l-5.813 1.912a2 2 0 0 0-1.275 1.275L12 21l-1.912-5.813a2 2 0 0 0-1.275-1.275L3 12l5.813-1.912a2 2 0 0 0 1.275-1.275L12 3z" />
+      </svg>
+      {isConfigured ? 'AI' : 'Set up AI'}
+    </button>
+  );
+}
+
+function AISettingsWrapper() {
+  const { settingsOpen, closeSettings } = useAI();
+  return <AISettingsModal open={settingsOpen} onClose={closeSettings} />;
+}
+
+function EditorAppInner({ initialCategory }: EditorAppProps) {
   // Import templates directly — functions can't cross the Astro→React serialization boundary
   const templates = useMemo(() => getAllTemplates(), []);
 
@@ -26,7 +59,7 @@ export function EditorApp({ initialCategory }: EditorAppProps) {
     return templates[0];
   }, [templates, initialCategory]);
 
-  const { state, setTemplate, setParam, resetDefaults, setCategory, setSearch, apiUrl, downloadUrl } =
+  const { state, setTemplate, setParam, setParams, resetDefaults, setCategory, setSearch, apiUrl, downloadUrl } =
     useEditorState(defaultTemplate);
 
   const { svg, loading, error, render } = useSatoriRenderer();
@@ -83,6 +116,29 @@ export function EditorApp({ initialCategory }: EditorAppProps) {
     }
   }, [currentTemplate, resetDefaults]);
 
+  const handleAutofill = useCallback(
+    (result: { templateId: string; fields: Record<string, string>; colors?: Record<string, string> }) => {
+      // Switch template
+      const template = getTemplate(result.templateId);
+      if (template) {
+        setTemplate(template);
+        // Apply autofilled fields after template switch
+        setTimeout(() => {
+          const merged = { ...result.fields };
+          if (result.colors) Object.assign(merged, result.colors);
+          setParams(merged);
+        }, 0);
+      } else {
+        // If template not found, just apply fields to current template
+        const merged = { ...result.fields };
+        if (result.colors) Object.assign(merged, result.colors);
+        setParams(merged);
+      }
+      if (isMobile) setMobileTab('customize');
+    },
+    [setTemplate, setParams, isMobile]
+  );
+
   return (
     <div className="editor-layout">
       {/* Top Bar */}
@@ -94,6 +150,7 @@ export function EditorApp({ initialCategory }: EditorAppProps) {
           <span className="editor-topbar-label">Template:</span>
           <span className="editor-topbar-name">{currentTemplate.name}</span>
         </div>
+        <AITopbarButton />
         <ExportBar apiUrl={apiUrl} downloadUrl={downloadUrl} params={state.params} templateId={state.templateId} />
       </div>
 
@@ -144,15 +201,22 @@ export function EditorApp({ initialCategory }: EditorAppProps) {
               />
             </div>
           ) : (
+            <>
             <CustomizePanel
               fields={currentTemplate.fields}
               params={state.params}
               onParamChange={setParam}
               onReset={handleReset}
+              category={currentTemplate.category}
+              autofill={<AIAutofill onAutofill={handleAutofill} />}
             />
+            </>
           )}
         </div>
       </div>
+
+      {/* AI Settings Modal */}
+      <AISettingsWrapper />
     </div>
   );
 }

--- a/src/components/editor/EditorApp.tsx
+++ b/src/components/editor/EditorApp.tsx
@@ -31,6 +31,17 @@ export function EditorApp({ initialCategory }: EditorAppProps) {
 
   const { svg, loading, error, render } = useSatoriRenderer();
   const [mobileTab, setMobileTab] = useState<'templates' | 'customize' | 'export'>('customize');
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth <= 768 : false
+  );
+
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 768px)');
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener('change', handler);
+    setIsMobile(mq.matches);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
 
   // Find current template definition (use registry lookup to ensure render function is present)
   const currentTemplate = useMemo(
@@ -59,8 +70,11 @@ export function EditorApp({ initialCategory }: EditorAppProps) {
   const handleTemplateSelect = useCallback(
     (template: TemplateDefinition) => {
       setTemplate(template);
+      if (isMobile) {
+        setMobileTab('customize');
+      }
     },
-    [setTemplate]
+    [setTemplate, isMobile]
   );
 
   const handleReset = useCallback(() => {
@@ -114,11 +128,20 @@ export function EditorApp({ initialCategory }: EditorAppProps) {
           />
         </div>
 
-        {/* Right: Customize */}
+        {/* Right: Customize / Export */}
         <div className={`editor-right ${mobileTab === 'customize' || mobileTab === 'export' ? 'mobile-show' : 'mobile-hide'}`}>
           {mobileTab === 'export' ? (
             <div className="editor-export-mobile">
+              <div className="editor-export-preview">
+                <Canvas svg={svg} loading={loading} error={error} />
+              </div>
               <ExportBar apiUrl={apiUrl} downloadUrl={downloadUrl} params={state.params} templateId={state.templateId} />
+              <PlatformPreviewStrip
+                svg={svg}
+                title={String(state.params.title || '')}
+                description={String(state.params.description || '')}
+                siteName={String(state.params.siteName || '')}
+              />
             </div>
           ) : (
             <CustomizePanel

--- a/src/components/editor/ExportBar.tsx
+++ b/src/components/editor/ExportBar.tsx
@@ -117,13 +117,15 @@ export function ExportBar({ apiUrl, downloadUrl, params, templateId }: ExportBar
           className="export-btn export-btn-ghost"
           onClick={() => copyToClipboard(apiUrl, 'url')}
         >
-          {copied === 'url' ? 'Copied!' : 'Copy URL'}
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+          {copied === 'url' ? 'Copied!' : 'Copy Image URL'}
         </button>
         <button
           type="button"
           className="export-btn export-btn-ghost"
           onClick={() => copyToClipboard(metaTags, 'meta')}
         >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
           {copied === 'meta' ? 'Copied!' : 'Copy Meta Tags'}
         </button>
       </div>

--- a/src/components/editor/TemplatePanel.tsx
+++ b/src/components/editor/TemplatePanel.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import type { TemplateDefinition, TemplateCategory } from '@/templates/types';
 import { CATEGORY_META, ALL_CATEGORIES } from '@/templates/types';
 import { TemplateThumbnail } from './TemplateThumbnail';
+import { AITemplateSearch } from './AITemplateSearch';
 
 interface TemplatePanelProps {
   templates: TemplateDefinition[];
@@ -49,6 +50,7 @@ export function TemplatePanel({
           value={searchQuery}
           onChange={(e) => onSearchChange(e.target.value)}
         />
+        <AITemplateSearch templates={templates} onTemplateSelect={onTemplateSelect} />
       </div>
       <div className="template-categories">
         <button

--- a/src/components/editor/TextInput.tsx
+++ b/src/components/editor/TextInput.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 interface TextInputProps {
   label: string;
   value: string;
@@ -5,17 +7,22 @@ interface TextInputProps {
   placeholder?: string;
   required?: boolean;
   multiline?: boolean;
+  /** Optional element rendered inline after the label (e.g. AI generate button) */
+  action?: ReactNode;
 }
 
-export function TextInput({ label, value, onChange, placeholder, required, multiline }: TextInputProps) {
+export function TextInput({ label, value, onChange, placeholder, required, multiline, action }: TextInputProps) {
   const id = `field-${label.toLowerCase().replace(/\s+/g, '-')}`;
 
   return (
     <div className="editor-field">
-      <label htmlFor={id} className="editor-field-label">
-        {label}
-        {required && <span className="editor-field-required">*</span>}
-      </label>
+      <div className="editor-field-label-row">
+        <label htmlFor={id} className="editor-field-label">
+          {label}
+          {required && <span className="editor-field-required">*</span>}
+        </label>
+        {action}
+      </div>
       {multiline ? (
         <textarea
           id={id}

--- a/src/components/editor/useEditorState.ts
+++ b/src/components/editor/useEditorState.ts
@@ -64,6 +64,10 @@ export function useEditorState(initialTemplate: TemplateDefinition) {
     dispatch({ type: 'SET_PARAM', key, value });
   }, []);
 
+  const setParams = useCallback((params: Record<string, any>) => {
+    dispatch({ type: 'SET_PARAMS', params });
+  }, []);
+
   const resetDefaults = useCallback((defaults: Record<string, any>) => {
     dispatch({ type: 'RESET_DEFAULTS', defaults });
   }, []);
@@ -104,6 +108,7 @@ export function useEditorState(initialTemplate: TemplateDefinition) {
     state,
     setTemplate,
     setParam,
+    setParams,
     resetDefaults,
     setCategory,
     setSearch,

--- a/src/components/preview/AIAnalyzer.tsx
+++ b/src/components/preview/AIAnalyzer.tsx
@@ -1,0 +1,208 @@
+import { useState, useCallback } from 'react';
+import type { MetaTags } from '@/lib/meta-fetcher';
+import { getApiKey, getSelectedProvider, getSelectedModel, hasAnyKeyConfigured } from '@/lib/ai/storage';
+import { getProvider, getDefaultModel } from '@/lib/ai/providers';
+
+interface AIAnalyzerProps {
+  meta: MetaTags;
+  url: string;
+}
+
+interface AnalysisSection {
+  good: string[];
+  improvements: string[];
+  issues: string[];
+  score: number;
+  suggestedTitle?: string;
+  suggestedDescription?: string;
+}
+
+export function AIAnalyzer({ meta, url }: AIAnalyzerProps) {
+  const [analysis, setAnalysis] = useState<AnalysisSection | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isConfigured = hasAnyKeyConfigured();
+
+  const handleAnalyze = useCallback(async () => {
+    const provider = getSelectedProvider();
+    if (!provider) return;
+    const apiKey = getApiKey(provider);
+    const providerConfig = getProvider(provider);
+    if (!apiKey || !providerConfig) return;
+    const model = getSelectedModel(provider) ?? getDefaultModel(provider);
+    if (!model) return;
+
+    setLoading(true);
+    setError(null);
+
+    const metaSummary = Object.entries(meta)
+      .filter(([, v]) => v)
+      .map(([k, v]) => `${k}: ${String(v).slice(0, 200)}`)
+      .join('\n');
+
+    const systemPrompt = `You are an SEO and social media expert. Analyze meta tags for social sharing best practices. Return valid JSON only.`;
+
+    const prompt = `Analyze these meta tags for the URL: ${url}
+
+META TAGS:
+${metaSummary}
+
+Return JSON with this shape:
+{
+  "score": <1-10 quality rating>,
+  "good": ["things done well"],
+  "improvements": ["suggestions to improve"],
+  "issues": ["critical problems"],
+  "suggestedTitle": "better title if current is weak (max 60 chars)",
+  "suggestedDescription": "better description if current is weak (max 155 chars)"
+}
+
+Consider: title length/quality, description quality, OG image presence/dimensions, Twitter card type, missing tags (og:locale, twitter:image:alt), platform-specific truncation risks.`;
+
+    try {
+      const res = await fetch('/api/ai/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          provider,
+          apiKey,
+          model,
+          prompt,
+          systemPrompt,
+          maxTokens: 500,
+          temperature: 0.3,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({ error: 'Analysis failed' }));
+        throw new Error(data.error || `HTTP ${res.status}`);
+      }
+
+      const data = await res.json();
+      const content = data.content.trim();
+
+      // Parse JSON response
+      let parsed: AnalysisSection;
+      try {
+        const jsonMatch = content.match(/\{[\s\S]*\}/);
+        parsed = JSON.parse(jsonMatch ? jsonMatch[0] : content);
+      } catch {
+        throw new Error('Could not parse AI response');
+      }
+
+      setAnalysis(parsed);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Analysis failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [meta, url]);
+
+  if (!isConfigured) {
+    return null; // Don't show AI analyzer if no key configured
+  }
+
+  return (
+    <div className="ai-analyzer">
+      {!analysis && (
+        <button
+          type="button"
+          className="ai-analyzer-btn"
+          onClick={handleAnalyze}
+          disabled={loading}
+        >
+          {loading ? (
+            <>
+              <span className="ai-spinner-dark" />
+              Analyzing...
+            </>
+          ) : (
+            <>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M12 3l1.912 5.813a2 2 0 0 0 1.275 1.275L21 12l-5.813 1.912a2 2 0 0 0-1.275 1.275L12 21l-1.912-5.813a2 2 0 0 0-1.275-1.275L3 12l5.813-1.912a2 2 0 0 0 1.275-1.275L12 3z" />
+              </svg>
+              Analyze with AI
+            </>
+          )}
+        </button>
+      )}
+
+      {error && (
+        <div className="ai-analyzer-error">{error}</div>
+      )}
+
+      {analysis && (
+        <div className="ai-analyzer-results">
+          <div className="ai-analyzer-header">
+            <h4 className="ai-analyzer-title">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M12 3l1.912 5.813a2 2 0 0 0 1.275 1.275L21 12l-5.813 1.912a2 2 0 0 0-1.275 1.275L12 21l-1.912-5.813a2 2 0 0 0-1.275-1.275L3 12l5.813-1.912a2 2 0 0 0 1.275-1.275L12 3z" />
+              </svg>
+              AI Analysis
+            </h4>
+            <div className="ai-analyzer-score">
+              <span className="ai-analyzer-score-num">{analysis.score}/10</span>
+              <div className="ai-analyzer-score-bar">
+                <div className="ai-analyzer-score-fill" style={{ width: `${analysis.score * 10}%` }} />
+              </div>
+            </div>
+          </div>
+
+          {analysis.good?.length > 0 && (
+            <div className="ai-analyzer-section">
+              <h5 className="ai-analyzer-section-title ai-section-good">Good</h5>
+              <ul className="ai-analyzer-list">
+                {analysis.good.map((item, i) => <li key={i}>{item}</li>)}
+              </ul>
+            </div>
+          )}
+
+          {analysis.improvements?.length > 0 && (
+            <div className="ai-analyzer-section">
+              <h5 className="ai-analyzer-section-title ai-section-warn">Improvements</h5>
+              <ul className="ai-analyzer-list">
+                {analysis.improvements.map((item, i) => <li key={i}>{item}</li>)}
+              </ul>
+            </div>
+          )}
+
+          {analysis.issues?.length > 0 && (
+            <div className="ai-analyzer-section">
+              <h5 className="ai-analyzer-section-title ai-section-error">Issues</h5>
+              <ul className="ai-analyzer-list">
+                {analysis.issues.map((item, i) => <li key={i}>{item}</li>)}
+              </ul>
+            </div>
+          )}
+
+          {(analysis.suggestedTitle || analysis.suggestedDescription) && (
+            <div className="ai-analyzer-section">
+              <h5 className="ai-analyzer-section-title">Suggested Rewrites</h5>
+              {analysis.suggestedTitle && (
+                <div className="ai-analyzer-suggestion">
+                  <span className="ai-analyzer-suggestion-label">Title:</span>
+                  <span>{analysis.suggestedTitle}</span>
+                </div>
+              )}
+              {analysis.suggestedDescription && (
+                <div className="ai-analyzer-suggestion">
+                  <span className="ai-analyzer-suggestion-label">Description:</span>
+                  <span>{analysis.suggestedDescription}</span>
+                </div>
+              )}
+            </div>
+          )}
+
+          <a href={`/create?autofill=${encodeURIComponent(url)}`} className="ai-analyzer-cta">
+            Create OG Image for this URL
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" />
+            </svg>
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/preview/PreviewApp.tsx
+++ b/src/components/preview/PreviewApp.tsx
@@ -3,6 +3,7 @@ import { URLInput } from './URLInput';
 import { PlatformGrid } from './PlatformGrid';
 import { MetaTagReport } from './MetaTagReport';
 import { FixItButton } from './FixItButton';
+import { AIAnalyzer } from './AIAnalyzer';
 
 export function PreviewApp() {
   const { url, setUrl, loading, error, data, checkUrl } = usePreviewState();
@@ -30,6 +31,7 @@ export function PreviewApp() {
       {data && (
         <div className="preview-results">
           <MetaTagReport analysis={data.analysis} meta={data.meta} />
+          <AIAnalyzer meta={data.meta} url={data.url} />
           <PlatformGrid platforms={data.platforms} />
           <FixItButton meta={data.meta} />
         </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -5,6 +5,7 @@ import Footer from '../components/Footer.astro';
 import Toast from '../components/Toast.astro';
 import StarBanner from '../components/StarBanner.astro';
 import BackToTop from '../components/BackToTop.astro';
+import FeedbackButton from '../components/FeedbackButton.astro';
 import '../styles/global.css';
 
 interface Props {
@@ -114,6 +115,7 @@ const fullTitle = title === 'OGCOPS' ? title : `${title} | ${siteName}`;
     <Toast />
     <StarBanner />
     <BackToTop />
+    <FeedbackButton />
   </body>
 </html>
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -31,7 +31,7 @@ const fullTitle = title === 'OGCOPS' ? title : `${title} | ${siteName}`;
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content={description} />
     {noindex && <meta name="robots" content="noindex, nofollow" />}
     <link rel="canonical" href={canonicalURL} />
@@ -106,7 +106,7 @@ const fullTitle = title === 'OGCOPS' ? title : `${title} | ${siteName}`;
     <slot name="head" />
   </head>
   <body>
-    <Header transition:persist />
+    <Header />
     <main transition:animate="fade">
       <slot />
     </main>

--- a/src/layouts/ToolLayout.astro
+++ b/src/layouts/ToolLayout.astro
@@ -19,7 +19,7 @@ const fullTitle = `${title} | ${siteName}`;
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content={description} />
 
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
@@ -61,7 +61,14 @@ const fullTitle = `${title} | ${siteName}`;
   body {
     display: flex;
     flex-direction: column;
+    min-height: 100vh;
+    min-height: 100dvh;
     height: 100vh;
+    height: 100dvh;
     overflow: hidden;
+    padding-top: env(safe-area-inset-top);
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+    padding-bottom: env(safe-area-inset-bottom);
   }
 </style>

--- a/src/lib/ai/autofill.ts
+++ b/src/lib/ai/autofill.ts
@@ -1,0 +1,96 @@
+import { getAllTemplates } from '@/templates/registry';
+
+export interface AutofillResult {
+  templateId: string;
+  fields: Record<string, string>;
+  colors?: {
+    bgColor?: string;
+    accentColor?: string;
+    textColor?: string;
+  };
+}
+
+/**
+ * Build the prompt for Smart Autofill — given page content, pick the best template and fill fields.
+ */
+export function buildAutofillPrompt(pageContent: {
+  title?: string;
+  description?: string;
+  headings?: string[];
+  bodyText?: string;
+  ogTags?: Record<string, string>;
+  themeColor?: string;
+}): { prompt: string; systemPrompt: string } {
+  // Build a compact template catalog
+  const templates = getAllTemplates();
+  const catalog = templates.map((t) => ({
+    id: t.id,
+    category: t.category,
+    name: t.name,
+    fields: t.fields.map((f) => f.key).join(', '),
+  }));
+
+  const systemPrompt = `You are an expert at analyzing web pages and generating OG image content. Given page content and a list of available templates, select the best matching template and generate field values. Always return valid JSON.`;
+
+  const prompt = `Analyze this page content and select the best OG image template.
+
+PAGE CONTENT:
+Title: ${pageContent.title || '(none)'}
+Description: ${pageContent.description || '(none)'}
+${pageContent.headings?.length ? `Headings: ${pageContent.headings.slice(0, 5).join(', ')}` : ''}
+${pageContent.bodyText ? `Content preview: ${pageContent.bodyText.slice(0, 1500)}` : ''}
+${pageContent.themeColor ? `Theme color: ${pageContent.themeColor}` : ''}
+
+AVAILABLE TEMPLATES:
+${JSON.stringify(catalog, null, 0)}
+
+Return JSON with this exact shape:
+{
+  "templateId": "the-best-template-id",
+  "fields": { "title": "...", "description": "...", "author": "...", ... },
+  "colors": { "bgColor": "#hex", "accentColor": "#hex" }
+}
+
+Rules:
+- Pick the template whose category best matches the page content type
+- Title max 60 chars, description max 80 chars
+- Extract author name if visible
+- Detect brand colors from the page if possible
+- Only include field keys that exist in the template's field list
+- Return ONLY the JSON object, no explanation`;
+
+  return { prompt, systemPrompt };
+}
+
+/**
+ * Parse the autofill response from AI.
+ */
+export function parseAutofillResponse(text: string): AutofillResult | null {
+  const trimmed = text.trim();
+
+  // Try parsing directly
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (parsed.templateId && parsed.fields) return parsed as AutofillResult;
+  } catch {}
+
+  // Try extracting from code block
+  const codeBlockMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (codeBlockMatch) {
+    try {
+      const parsed = JSON.parse(codeBlockMatch[1].trim());
+      if (parsed.templateId && parsed.fields) return parsed as AutofillResult;
+    } catch {}
+  }
+
+  // Try finding JSON object in text
+  const objectMatch = trimmed.match(/\{[\s\S]*\}/);
+  if (objectMatch) {
+    try {
+      const parsed = JSON.parse(objectMatch[0]);
+      if (parsed.templateId && parsed.fields) return parsed as AutofillResult;
+    } catch {}
+  }
+
+  return null;
+}

--- a/src/lib/ai/generate.ts
+++ b/src/lib/ai/generate.ts
@@ -1,0 +1,86 @@
+import type { GenerateContext } from './prompts';
+import { getPromptForField } from './prompts';
+import { getApiKey, getSelectedProvider, getSelectedModel } from './storage';
+import { getDefaultModel } from './providers';
+
+/**
+ * Parse AI response text into an array of strings.
+ * Handles: clean JSON, markdown-wrapped JSON, plain text fallback.
+ */
+export function parseAIResponse(text: string): string[] {
+  const trimmed = text.trim();
+
+  // Try parsing as-is
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (Array.isArray(parsed)) return parsed.filter((s) => typeof s === 'string');
+  } catch {}
+
+  // Try extracting JSON from markdown code block
+  const codeBlockMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (codeBlockMatch) {
+    try {
+      const parsed = JSON.parse(codeBlockMatch[1].trim());
+      if (Array.isArray(parsed)) return parsed.filter((s) => typeof s === 'string');
+    } catch {}
+  }
+
+  // Try finding array pattern in the text
+  const arrayMatch = trimmed.match(/\[[\s\S]*\]/);
+  if (arrayMatch) {
+    try {
+      const parsed = JSON.parse(arrayMatch[0]);
+      if (Array.isArray(parsed)) return parsed.filter((s) => typeof s === 'string');
+    } catch {}
+  }
+
+  // Fallback: split by newlines, filter numbered list items
+  return trimmed
+    .split('\n')
+    .map((line) => line.replace(/^\d+[\.\)]\s*/, '').replace(/^[-*]\s*/, '').replace(/^["']|["']$/g, '').trim())
+    .filter((line) => line.length > 0 && line.length <= 100);
+}
+
+/**
+ * Generate suggestions for a field by calling the AI proxy endpoint.
+ */
+export async function generateSuggestions(ctx: GenerateContext): Promise<string[]> {
+  const provider = getSelectedProvider();
+  if (!provider) throw new Error('No AI provider configured');
+
+  const apiKey = getApiKey(provider);
+  if (!apiKey) throw new Error('No API key configured');
+
+  const model = getSelectedModel(provider) ?? getDefaultModel(provider);
+  if (!model) throw new Error('No model selected');
+
+  const { prompt, systemPrompt } = getPromptForField(ctx);
+
+  const res = await fetch('/api/ai/generate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      provider,
+      apiKey,
+      model,
+      prompt,
+      systemPrompt,
+      maxTokens: 300,
+      temperature: 0.8,
+    }),
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: 'Generation failed' }));
+    throw new Error(err.error || `HTTP ${res.status}`);
+  }
+
+  const data = await res.json();
+  const suggestions = parseAIResponse(data.content);
+
+  if (suggestions.length === 0) {
+    throw new Error('Could not parse AI response');
+  }
+
+  return suggestions;
+}

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -1,0 +1,79 @@
+export interface GenerateContext {
+  fieldName: string;
+  category?: string;
+  currentValues?: Record<string, string>;
+  count?: number;
+}
+
+export function buildTitlePrompt(ctx: GenerateContext): { prompt: string; systemPrompt: string } {
+  const count = ctx.count ?? 3;
+  const category = ctx.category || 'general';
+  const existingContext = buildExistingFieldsContext(ctx.currentValues);
+
+  return {
+    systemPrompt: `You are an expert copywriter specializing in social media and OG image text. Generate compelling, click-worthy text options. Always return a JSON array of strings — no explanation, no markdown, just the array.`,
+    prompt: `Generate ${count} compelling title options for an OG image.
+
+Rules:
+- Maximum 60 characters per title (OG images have limited space)
+- Be specific and intriguing, avoid generic phrases
+- Category: ${category}
+${existingContext}
+Return as a JSON array of strings. Example: ["Title One", "Title Two", "Title Three"]`,
+  };
+}
+
+export function buildSubtitlePrompt(ctx: GenerateContext): { prompt: string; systemPrompt: string } {
+  const count = ctx.count ?? 3;
+  const category = ctx.category || 'general';
+  const title = ctx.currentValues?.title || '';
+  const existingContext = buildExistingFieldsContext(ctx.currentValues);
+
+  return {
+    systemPrompt: `You are an expert copywriter specializing in social media and OG image text. Generate compelling subtitle/description options. Always return a JSON array of strings — no explanation, no markdown, just the array.`,
+    prompt: `Generate ${count} concise subtitle options for an OG image.
+
+Rules:
+- Maximum 80 characters per subtitle
+${title ? `- Complement the title: "${title}"` : '- Create a standalone subtitle'}
+- Add context without repeating the title
+- Category: ${category}
+${existingContext}
+Return as a JSON array of strings. Example: ["Subtitle One", "Subtitle Two", "Subtitle Three"]`,
+  };
+}
+
+export function buildGenericFieldPrompt(ctx: GenerateContext): { prompt: string; systemPrompt: string } {
+  const count = ctx.count ?? 3;
+  const category = ctx.category || 'general';
+  const fieldName = ctx.fieldName;
+  const existingContext = buildExistingFieldsContext(ctx.currentValues);
+
+  return {
+    systemPrompt: `You are an expert copywriter specializing in social media and OG image text. Generate options for the "${fieldName}" field. Always return a JSON array of strings — no explanation, no markdown, just the array.`,
+    prompt: `Generate ${count} options for the "${fieldName}" field of an OG image.
+
+Rules:
+- Keep it concise (under 60 characters)
+- Category: ${category}
+${existingContext}
+Return as a JSON array of strings.`,
+  };
+}
+
+function buildExistingFieldsContext(values?: Record<string, string>): string {
+  if (!values) return '';
+  const relevant = Object.entries(values)
+    .filter(([_, v]) => v && v.trim().length > 0)
+    .map(([k, v]) => `  ${k}: "${v}"`)
+    .join('\n');
+  if (!relevant) return '';
+  return `\nExisting fields for context:\n${relevant}\n`;
+}
+
+export function getPromptForField(ctx: GenerateContext): { prompt: string; systemPrompt: string } {
+  const name = ctx.fieldName.toLowerCase();
+  if (name === 'title') return buildTitlePrompt(ctx);
+  if (name === 'subtitle' || name === 'description') return buildSubtitlePrompt(ctx);
+  return buildGenericFieldPrompt(ctx);
+}

--- a/src/lib/ai/providers.ts
+++ b/src/lib/ai/providers.ts
@@ -1,0 +1,243 @@
+import type { AIProviderConfig, AIGenerateResponse, AIProvider } from './types';
+
+// --- Response parsers ---
+
+function parseOpenAIResponse(data: unknown): AIGenerateResponse {
+  const d = data as any;
+  const choice = d.choices?.[0];
+  return {
+    content: choice?.message?.content ?? '',
+    model: d.model ?? '',
+    usage: d.usage
+      ? { inputTokens: d.usage.prompt_tokens ?? 0, outputTokens: d.usage.completion_tokens ?? 0 }
+      : undefined,
+  };
+}
+
+function parseAnthropicResponse(data: unknown): AIGenerateResponse {
+  const d = data as any;
+  const text = d.content?.[0]?.text ?? '';
+  return {
+    content: text,
+    model: d.model ?? '',
+    usage: d.usage
+      ? { inputTokens: d.usage.input_tokens ?? 0, outputTokens: d.usage.output_tokens ?? 0 }
+      : undefined,
+  };
+}
+
+function parseGoogleResponse(data: unknown): AIGenerateResponse {
+  const d = data as any;
+  const text = d.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+  return {
+    content: text,
+    model: d.modelVersion ?? '',
+    usage: d.usageMetadata
+      ? {
+          inputTokens: d.usageMetadata.promptTokenCount ?? 0,
+          outputTokens: d.usageMetadata.candidatesTokenCount ?? 0,
+        }
+      : undefined,
+  };
+}
+
+// --- OpenAI-compatible body formatter (shared by OpenAI, Groq, OpenRouter) ---
+
+function openAICompatibleBody(baseUrl: string) {
+  return (params: {
+    model: string;
+    prompt: string;
+    systemPrompt?: string;
+    maxTokens?: number;
+    temperature?: number;
+  }) => {
+    const messages: Array<{ role: string; content: string }> = [];
+    if (params.systemPrompt) {
+      messages.push({ role: 'system', content: params.systemPrompt });
+    }
+    messages.push({ role: 'user', content: params.prompt });
+
+    return {
+      url: `${baseUrl}/chat/completions`,
+      body: {
+        model: params.model,
+        messages,
+        max_tokens: params.maxTokens ?? 300,
+        temperature: params.temperature ?? 0.8,
+      },
+    };
+  };
+}
+
+// --- Provider configs ---
+
+const openai: AIProviderConfig = {
+  id: 'openai',
+  name: 'OpenAI',
+  baseUrl: 'https://api.openai.com/v1',
+  apiKeyUrl: 'https://platform.openai.com/api-keys',
+  models: [
+    { id: 'gpt-4o', name: 'GPT-4o', provider: 'openai', maxTokens: 4096, description: 'Most capable' },
+    { id: 'gpt-4o-mini', name: 'GPT-4o Mini', provider: 'openai', maxTokens: 4096, description: 'Fast, affordable' },
+  ],
+  headerBuilder: (apiKey) => ({
+    'Authorization': `Bearer ${apiKey}`,
+    'Content-Type': 'application/json',
+  }),
+  bodyFormatter: openAICompatibleBody('https://api.openai.com/v1'),
+  responseParser: parseOpenAIResponse,
+  validateRequest: (apiKey) => ({
+    url: 'https://api.openai.com/v1/models',
+    method: 'GET',
+    headers: { 'Authorization': `Bearer ${apiKey}` },
+  }),
+};
+
+const anthropic: AIProviderConfig = {
+  id: 'anthropic',
+  name: 'Anthropic',
+  baseUrl: 'https://api.anthropic.com/v1',
+  apiKeyUrl: 'https://console.anthropic.com/settings/keys',
+  models: [
+    { id: 'claude-sonnet-4-6', name: 'Claude Sonnet', provider: 'anthropic', maxTokens: 4096, description: 'Best writing quality' },
+    { id: 'claude-haiku-4-5', name: 'Claude Haiku', provider: 'anthropic', maxTokens: 4096, description: 'Fast, affordable' },
+  ],
+  headerBuilder: (apiKey) => ({
+    'x-api-key': apiKey,
+    'anthropic-version': '2023-06-01',
+    'Content-Type': 'application/json',
+  }),
+  bodyFormatter: (params) => ({
+    url: 'https://api.anthropic.com/v1/messages',
+    body: {
+      model: params.model,
+      max_tokens: params.maxTokens ?? 300,
+      ...(params.systemPrompt ? { system: params.systemPrompt } : {}),
+      messages: [{ role: 'user', content: params.prompt }],
+      temperature: params.temperature ?? 0.8,
+    },
+  }),
+  responseParser: parseAnthropicResponse,
+  validateRequest: (apiKey) => ({
+    url: 'https://api.anthropic.com/v1/messages',
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'Content-Type': 'application/json',
+    },
+  }),
+};
+
+const google: AIProviderConfig = {
+  id: 'google',
+  name: 'Google',
+  baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
+  apiKeyUrl: 'https://aistudio.google.com/apikey',
+  models: [
+    { id: 'gemini-2.0-flash', name: 'Gemini 2.0 Flash', provider: 'google', maxTokens: 4096, description: 'Fast, free tier' },
+    { id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro', provider: 'google', maxTokens: 4096, description: 'Most capable' },
+  ],
+  headerBuilder: () => ({
+    'Content-Type': 'application/json',
+  }),
+  bodyFormatter: (params) => ({
+    url: `https://generativelanguage.googleapis.com/v1beta/models/${params.model}:generateContent`,
+    body: {
+      contents: [
+        {
+          parts: [
+            { text: params.systemPrompt ? `${params.systemPrompt}\n\n${params.prompt}` : params.prompt },
+          ],
+        },
+      ],
+      generationConfig: {
+        maxOutputTokens: params.maxTokens ?? 300,
+        temperature: params.temperature ?? 0.8,
+      },
+    },
+  }),
+  responseParser: parseGoogleResponse,
+  validateRequest: (apiKey) => ({
+    url: `https://generativelanguage.googleapis.com/v1beta/models?key=${apiKey}`,
+    method: 'GET',
+    headers: {},
+  }),
+};
+
+const groq: AIProviderConfig = {
+  id: 'groq',
+  name: 'Groq',
+  baseUrl: 'https://api.groq.com/openai/v1',
+  apiKeyUrl: 'https://console.groq.com/keys',
+  models: [
+    { id: 'llama-3.3-70b-versatile', name: 'Llama 3.3 70B', provider: 'groq', maxTokens: 4096, description: 'Very fast, free tier' },
+    { id: 'mixtral-8x7b-32768', name: 'Mixtral 8x7B', provider: 'groq', maxTokens: 4096, description: 'Fast, versatile' },
+  ],
+  headerBuilder: (apiKey) => ({
+    'Authorization': `Bearer ${apiKey}`,
+    'Content-Type': 'application/json',
+  }),
+  bodyFormatter: openAICompatibleBody('https://api.groq.com/openai/v1'),
+  responseParser: parseOpenAIResponse,
+  validateRequest: (apiKey) => ({
+    url: 'https://api.groq.com/openai/v1/models',
+    method: 'GET',
+    headers: { 'Authorization': `Bearer ${apiKey}` },
+  }),
+};
+
+const openrouter: AIProviderConfig = {
+  id: 'openrouter',
+  name: 'OpenRouter',
+  baseUrl: 'https://openrouter.ai/api/v1',
+  apiKeyUrl: 'https://openrouter.ai/keys',
+  models: [
+    { id: 'openai/gpt-4o-mini', name: 'GPT-4o Mini (via OR)', provider: 'openrouter', maxTokens: 4096, description: 'Access any model' },
+    { id: 'anthropic/claude-haiku-4-5', name: 'Claude Haiku (via OR)', provider: 'openrouter', maxTokens: 4096, description: 'One key, all models' },
+  ],
+  headerBuilder: (apiKey) => ({
+    'Authorization': `Bearer ${apiKey}`,
+    'Content-Type': 'application/json',
+    'HTTP-Referer': 'https://og.codercops.com',
+    'X-Title': 'OGCOPS',
+  }),
+  bodyFormatter: openAICompatibleBody('https://openrouter.ai/api/v1'),
+  responseParser: parseOpenAIResponse,
+  validateRequest: (apiKey) => ({
+    url: 'https://openrouter.ai/api/v1/models',
+    method: 'GET',
+    headers: { 'Authorization': `Bearer ${apiKey}` },
+  }),
+};
+
+// --- Registry ---
+
+const providerRegistry = new Map<AIProvider, AIProviderConfig>([
+  ['openai', openai],
+  ['anthropic', anthropic],
+  ['google', google],
+  ['groq', groq],
+  ['openrouter', openrouter],
+]);
+
+export function getProvider(id: AIProvider): AIProviderConfig | undefined {
+  return providerRegistry.get(id);
+}
+
+export function getAllProviders(): AIProviderConfig[] {
+  return Array.from(providerRegistry.values());
+}
+
+export function getModelsForProvider(id: AIProvider): AIProviderConfig['models'] {
+  return providerRegistry.get(id)?.models ?? [];
+}
+
+export function getDefaultModel(providerId: AIProvider): string | undefined {
+  const provider = providerRegistry.get(providerId);
+  return provider?.models[0]?.id;
+}
+
+export function isValidProvider(id: string): id is AIProvider {
+  return providerRegistry.has(id as AIProvider);
+}

--- a/src/lib/ai/recommender.ts
+++ b/src/lib/ai/recommender.ts
@@ -1,0 +1,80 @@
+import { getAllTemplates } from '@/templates/registry';
+
+export interface TemplateRecommendation {
+  id: string;
+  score: number;
+  reason: string;
+}
+
+/**
+ * Build prompt for template recommendation based on natural language query.
+ */
+export function buildRecommenderPrompt(query: string): { prompt: string; systemPrompt: string } {
+  const templates = getAllTemplates();
+  const catalog = templates.map((t) => ({
+    id: t.id,
+    category: t.category,
+    name: t.name,
+    description: t.description,
+    tags: t.tags.join(', '),
+  }));
+
+  return {
+    systemPrompt: `You are an expert at matching user needs to OG image templates. Given a natural language description, find the best matching templates from the catalog. Always return valid JSON.`,
+    prompt: `User is looking for: "${query}"
+
+Available templates:
+${JSON.stringify(catalog, null, 0)}
+
+Return the top 5 best matching templates as a JSON array:
+[{ "id": "template-id", "score": 95, "reason": "brief reason" }]
+
+Score should be 0-100 based on how well the template matches. Only return valid JSON array.`,
+  };
+}
+
+/**
+ * Parse the recommender response from AI.
+ */
+export function parseRecommenderResponse(text: string): TemplateRecommendation[] {
+  const trimmed = text.trim();
+
+  // Try parsing as array
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (Array.isArray(parsed)) return validateRecommendations(parsed);
+  } catch {}
+
+  // Try extracting from code block
+  const codeBlockMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (codeBlockMatch) {
+    try {
+      const parsed = JSON.parse(codeBlockMatch[1].trim());
+      if (Array.isArray(parsed)) return validateRecommendations(parsed);
+    } catch {}
+  }
+
+  // Try finding array in text
+  const arrayMatch = trimmed.match(/\[[\s\S]*\]/);
+  if (arrayMatch) {
+    try {
+      const parsed = JSON.parse(arrayMatch[0]);
+      if (Array.isArray(parsed)) return validateRecommendations(parsed);
+    } catch {}
+  }
+
+  return [];
+}
+
+function validateRecommendations(items: unknown[]): TemplateRecommendation[] {
+  return items
+    .filter((item): item is Record<string, unknown> =>
+      typeof item === 'object' && item !== null && 'id' in item
+    )
+    .map((item) => ({
+      id: String(item.id),
+      score: typeof item.score === 'number' ? item.score : 50,
+      reason: typeof item.reason === 'string' ? item.reason : '',
+    }))
+    .slice(0, 5);
+}

--- a/src/lib/ai/storage.ts
+++ b/src/lib/ai/storage.ts
@@ -1,0 +1,88 @@
+import type { AIProvider } from './types';
+
+const PREFIX = 'ogcops-ai';
+const PROVIDER_KEY = `${PREFIX}-provider`;
+const modelKey = (provider: AIProvider) => `${PREFIX}-model-${provider}`;
+const apiKeyKey = (provider: AIProvider) => `${PREFIX}-key-${provider}`;
+
+function safeGet(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeSet(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // localStorage may be full or unavailable (e.g. private browsing)
+  }
+}
+
+function safeRemove(key: string): void {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // ignore
+  }
+}
+
+export function getApiKey(provider: AIProvider): string | null {
+  return safeGet(apiKeyKey(provider));
+}
+
+export function setApiKey(provider: AIProvider, key: string): void {
+  safeSet(apiKeyKey(provider), key);
+}
+
+export function removeApiKey(provider: AIProvider): void {
+  safeRemove(apiKeyKey(provider));
+}
+
+export function clearAllApiKeys(): void {
+  try {
+    const keysToRemove: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key?.startsWith(PREFIX)) {
+        keysToRemove.push(key);
+      }
+    }
+    keysToRemove.forEach((key) => localStorage.removeItem(key));
+  } catch {
+    // ignore
+  }
+}
+
+export function getSelectedProvider(): AIProvider | null {
+  return safeGet(PROVIDER_KEY) as AIProvider | null;
+}
+
+export function setSelectedProvider(provider: AIProvider): void {
+  safeSet(PROVIDER_KEY, provider);
+}
+
+export function getSelectedModel(provider: AIProvider): string | null {
+  return safeGet(modelKey(provider));
+}
+
+export function setSelectedModel(provider: AIProvider, modelId: string): void {
+  safeSet(modelKey(provider), modelId);
+}
+
+export function hasAnyKeyConfigured(): boolean {
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key?.startsWith(`${PREFIX}-key-`)) {
+        const value = localStorage.getItem(key);
+        if (value && value.length > 0) return true;
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return false;
+}

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -1,0 +1,58 @@
+export type AIProvider = 'openai' | 'anthropic' | 'google' | 'groq' | 'openrouter';
+
+export interface AIModel {
+  id: string;
+  name: string;
+  provider: AIProvider;
+  maxTokens: number;
+  description: string;
+}
+
+export interface AIProviderConfig {
+  id: AIProvider;
+  name: string;
+  baseUrl: string;
+  models: AIModel[];
+  apiKeyUrl: string;
+  /** Build auth headers from the user's API key */
+  headerBuilder: (apiKey: string) => Record<string, string>;
+  /** Format the request body for this provider's API */
+  bodyFormatter: (params: {
+    model: string;
+    prompt: string;
+    systemPrompt?: string;
+    maxTokens?: number;
+    temperature?: number;
+  }) => { url: string; body: unknown };
+  /** Parse the provider's response into a common format */
+  responseParser: (data: unknown) => AIGenerateResponse;
+  /** Build the validation request (lightweight key check) */
+  validateRequest: (apiKey: string) => { url: string; method: string; headers: Record<string, string> };
+}
+
+export interface AIGenerateRequest {
+  provider: AIProvider;
+  apiKey: string;
+  model: string;
+  prompt: string;
+  systemPrompt?: string;
+  maxTokens?: number;
+  temperature?: number;
+}
+
+export interface AIGenerateResponse {
+  content: string;
+  model: string;
+  usage?: {
+    inputTokens: number;
+    outputTokens: number;
+  };
+}
+
+export interface AIValidationResult {
+  valid: boolean;
+  error?: string;
+  provider: AIProvider;
+}
+
+export const AI_PROVIDERS: AIProvider[] = ['openai', 'anthropic', 'google', 'groq', 'openrouter'];

--- a/src/lib/ai/validation.ts
+++ b/src/lib/ai/validation.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+const aiProviderEnum = z.enum(['openai', 'anthropic', 'google', 'groq', 'openrouter']);
+
+export const aiValidateSchema = z.object({
+  provider: aiProviderEnum,
+  apiKey: z.string().min(1, 'API key is required'),
+});
+
+export const aiGenerateSchema = z.object({
+  provider: aiProviderEnum,
+  apiKey: z.string().min(1, 'API key is required'),
+  model: z.string().min(1, 'Model is required'),
+  prompt: z.string().min(1, 'Prompt is required').max(10000, 'Prompt too long'),
+  systemPrompt: z.string().max(5000).optional(),
+  maxTokens: z.number().int().min(1).max(4096).optional(),
+  temperature: z.number().min(0).max(2).optional(),
+});
+
+export type AIValidateInput = z.infer<typeof aiValidateSchema>;
+export type AIGenerateInput = z.infer<typeof aiGenerateSchema>;

--- a/src/lib/og-engine.ts
+++ b/src/lib/og-engine.ts
@@ -83,7 +83,10 @@ export async function renderToPng(
 
   const svg = await renderToSvg(element, { width, height });
 
-  // Serialize access to Resvg — the WASM module is single-threaded
+  // Serialize access to Resvg — the WASM module is single-threaded.
+  // We must explicitly free WASM objects before leaving the lock,
+  // otherwise the GC finalizer can run during another render and
+  // trigger "recursive use of an object detected".
   return withRenderLock(async () => {
     const outputWidth = scaleDown ?? width;
     const resvg = new Resvg(svg, {
@@ -91,8 +94,11 @@ export async function renderToPng(
     });
     const pngData = resvg.render();
     const pngBytes = pngData.asPng();
-    // Return as ArrayBuffer (BodyInit-compatible)
-    return pngBytes.buffer.slice(pngBytes.byteOffset, pngBytes.byteOffset + pngBytes.byteLength) as ArrayBuffer;
+    // Copy bytes out before freeing WASM objects
+    const result = pngBytes.buffer.slice(pngBytes.byteOffset, pngBytes.byteOffset + pngBytes.byteLength) as ArrayBuffer;
+    pngData.free();
+    resvg.free();
+    return result;
   });
 }
 

--- a/src/pages/api-docs.astro
+++ b/src/pages/api-docs.astro
@@ -33,6 +33,18 @@ import '@/styles/api-docs.css';
           <svg class="api-sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg>
           Thumbnails
         </a>
+        <a href="#ai-generate" class="api-sidebar-link">
+          <svg class="api-sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l1.912 5.813a2 2 0 0 0 1.275 1.275L21 12l-5.813 1.912a2 2 0 0 0-1.275 1.275L12 21l-1.912-5.813a2 2 0 0 0-1.275-1.275L3 12l5.813-1.912a2 2 0 0 0 1.275-1.275L12 3z"/></svg>
+          AI Generate
+        </a>
+        <a href="#ai-validate" class="api-sidebar-link">
+          <svg class="api-sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
+          AI Validate
+        </a>
+        <a href="#ai-autofill" class="api-sidebar-link">
+          <svg class="api-sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><path d="M14 2v6h6"/></svg>
+          AI Autofill
+        </a>
       </nav>
     </aside>
 
@@ -244,6 +256,234 @@ with open("og-image.png", "wb") as f:
           </div>
           <pre class="code-block-body"><code>https://og.codercops.com/api/templates/\
 blog-minimal-dark/thumbnail.png</code></pre>
+        </div>
+      </div>
+
+      <!-- AI Generate -->
+      <div class="endpoint-card" id="ai-generate">
+        <div class="endpoint-header">
+          <span class="endpoint-method endpoint-method-post">POST</span>
+          <code class="endpoint-path">/api/ai/generate</code>
+        </div>
+        <p class="endpoint-desc">
+          Proxy text generation through your own AI provider API key (BYOK). Supports OpenAI, Anthropic, Google, Groq, and OpenRouter.
+          Your API key is passed through to the provider and never stored.
+        </p>
+
+        <h4>Request Body (JSON)</h4>
+        <div class="param-list">
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">provider</code>
+              <span class="param-type">string</span>
+              <span class="param-required">required</span>
+            </div>
+            <p class="param-desc">AI provider: <code>openai</code>, <code>anthropic</code>, <code>google</code>, <code>groq</code>, or <code>openrouter</code></p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">apiKey</code>
+              <span class="param-type">string</span>
+              <span class="param-required">required</span>
+            </div>
+            <p class="param-desc">Your API key for the selected provider</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">model</code>
+              <span class="param-type">string</span>
+              <span class="param-required">required</span>
+            </div>
+            <p class="param-desc">Model ID (e.g. <code>gpt-4o-mini</code>, <code>claude-sonnet-4-20250514</code>, <code>gemini-2.0-flash</code>)</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">prompt</code>
+              <span class="param-type">string</span>
+              <span class="param-required">required</span>
+            </div>
+            <p class="param-desc">User prompt (max 10,000 characters)</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">systemPrompt</code>
+              <span class="param-type">string</span>
+            </div>
+            <p class="param-desc">Optional system prompt (max 5,000 characters)</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">maxTokens</code>
+              <span class="param-type">number</span>
+            </div>
+            <p class="param-desc">Max response tokens, 1–4096 (default: provider default)</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">temperature</code>
+              <span class="param-type">number</span>
+            </div>
+            <p class="param-desc">Sampling temperature, 0–2 (default: provider default)</p>
+          </div>
+        </div>
+
+        <h4>Response</h4>
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-block-lang">JSON Response</span>
+            <button class="code-block-copy" data-copy type="button">Copy</button>
+          </div>
+          <pre class="code-block-body"><code>{`{ "content": "Generated text from the AI model" }`}</code></pre>
+        </div>
+
+        <h4>Example</h4>
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-block-lang">JavaScript</span>
+            <button class="code-block-copy" data-copy type="button">Copy</button>
+          </div>
+          <pre class="code-block-body"><code>{`const res = await fetch('https://og.codercops.com/api/ai/generate', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    provider: 'openai',
+    apiKey: 'sk-your-key',
+    model: 'gpt-4o-mini',
+    prompt: 'Generate 3 catchy titles for a blog post about React',
+    maxTokens: 200,
+    temperature: 0.7,
+  }),
+});
+
+const { content } = await res.json();`}</code></pre>
+        </div>
+
+        <h4>Error Codes</h4>
+        <div class="param-list">
+          <div class="param-item">
+            <div class="param-head"><code class="param-name">400</code></div>
+            <p class="param-desc">Invalid request body (missing fields or out-of-range values)</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head"><code class="param-name">401</code></div>
+            <p class="param-desc">Invalid API key or unauthorized</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head"><code class="param-name">429</code></div>
+            <p class="param-desc">Rate limited by the provider</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head"><code class="param-name">502</code></div>
+            <p class="param-desc">Provider returned an error</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- AI Validate -->
+      <div class="endpoint-card" id="ai-validate">
+        <div class="endpoint-header">
+          <span class="endpoint-method endpoint-method-post">POST</span>
+          <code class="endpoint-path">/api/ai/validate</code>
+        </div>
+        <p class="endpoint-desc">Validate an AI provider API key by making a minimal test request. Returns whether the key is valid.</p>
+
+        <h4>Request Body (JSON)</h4>
+        <div class="param-list">
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">provider</code>
+              <span class="param-type">string</span>
+              <span class="param-required">required</span>
+            </div>
+            <p class="param-desc">AI provider: <code>openai</code>, <code>anthropic</code>, <code>google</code>, <code>groq</code>, or <code>openrouter</code></p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">apiKey</code>
+              <span class="param-type">string</span>
+              <span class="param-required">required</span>
+            </div>
+            <p class="param-desc">API key to validate</p>
+          </div>
+        </div>
+
+        <h4>Response</h4>
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-block-lang">JSON Response</span>
+            <button class="code-block-copy" data-copy type="button">Copy</button>
+          </div>
+          <pre class="code-block-body"><code>{`{ "valid": true }
+// or
+{ "valid": false, "error": "Invalid API key" }`}</code></pre>
+        </div>
+      </div>
+
+      <!-- AI Autofill -->
+      <div class="endpoint-card" id="ai-autofill">
+        <div class="endpoint-header">
+          <span class="endpoint-method endpoint-method-post">POST</span>
+          <code class="endpoint-path">/api/ai/autofill</code>
+        </div>
+        <p class="endpoint-desc">
+          Analyze a URL's content and auto-generate template field values using AI.
+          Fetches the page, extracts content, then uses your AI key to suggest a template, fill fields, and pick colors.
+        </p>
+
+        <h4>Request Body (JSON)</h4>
+        <div class="param-list">
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">url</code>
+              <span class="param-type">string</span>
+              <span class="param-required">required</span>
+            </div>
+            <p class="param-desc">URL to analyze</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">provider</code>
+              <span class="param-type">string</span>
+              <span class="param-required">required</span>
+            </div>
+            <p class="param-desc">AI provider</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">apiKey</code>
+              <span class="param-type">string</span>
+              <span class="param-required">required</span>
+            </div>
+            <p class="param-desc">Your API key</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">model</code>
+              <span class="param-type">string</span>
+              <span class="param-required">required</span>
+            </div>
+            <p class="param-desc">Model ID</p>
+          </div>
+        </div>
+
+        <h4>Response</h4>
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-block-lang">JSON Response</span>
+            <button class="code-block-copy" data-copy type="button">Copy</button>
+          </div>
+          <pre class="code-block-body"><code>{`{
+  "templateId": "blog-minimal-dark",
+  "fields": {
+    "title": "Generated Title",
+    "description": "Generated description",
+    "author": "Author Name"
+  },
+  "colors": {
+    "bgColor": "#1a1a2e",
+    "accentColor": "#e07a5f"
+  }
+}`}</code></pre>
         </div>
       </div>
     </div>

--- a/src/pages/api-docs.astro
+++ b/src/pages/api-docs.astro
@@ -5,24 +5,29 @@ import '@/styles/api-docs.css';
 
 <Layout title="API Documentation" description="Free REST API to generate OG images, check meta tags, and list templates. No API key required.">
   <div class="api-docs">
-    <!-- Sidebar -->
+    <!-- Hero: always above the sticky bar on mobile -->
+    <div class="api-hero" id="overview">
+      <h1>API Documentation</h1>
+      <p class="api-intro">
+        Generate OG images, check URL meta tags, and list templates with our free REST API.
+        No API key required. CORS-enabled for browser use.
+      </p>
+    </div>
+
+    <!-- Sticky section nav -->
     <aside class="api-sidebar">
       <nav class="api-sidebar-nav">
-        <a href="#overview" class="api-sidebar-link active">
-          <svg class="api-sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
-          Overview
-        </a>
-        <a href="#generate" class="api-sidebar-link">
+        <a href="#generate" class="api-sidebar-link active">
           <svg class="api-sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>
-          Generate Image
+          Generate
         </a>
         <a href="#preview" class="api-sidebar-link">
           <svg class="api-sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
-          Preview URL
+          Preview
         </a>
         <a href="#templates" class="api-sidebar-link">
           <svg class="api-sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="7" height="7" x="3" y="3" rx="1"/><rect width="7" height="7" x="14" y="3" rx="1"/><rect width="7" height="7" x="14" y="14" rx="1"/><rect width="7" height="7" x="3" y="14" rx="1"/></svg>
-          List Templates
+          Templates
         </a>
         <a href="#thumbnail" class="api-sidebar-link">
           <svg class="api-sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg>
@@ -33,93 +38,90 @@ import '@/styles/api-docs.css';
 
     <!-- Content -->
     <div class="api-content">
-      <h1>API Documentation</h1>
-      <p class="api-intro">
-        Generate OG images, check URL meta tags, and list templates with our free REST API.
-        No API key required. CORS-enabled for browser use.
-      </p>
-
       <!-- Generate Image -->
       <div class="endpoint-card" id="generate">
         <div class="endpoint-header">
           <span class="endpoint-method">GET</span>
-          <span class="endpoint-path">/api/og</span>
-          <a href="#generate" class="section-anchor" aria-label="Link to this section">#</a>
+          <code class="endpoint-path">/api/og</code>
         </div>
-        <p class="endpoint-desc">Generate an OG image as PNG. Returns image/png with Cache-Control headers.</p>
+        <p class="endpoint-desc">Generate an OG image as PNG. Returns <code>image/png</code> with Cache-Control headers.</p>
 
         <h4>Parameters</h4>
-        <table class="param-table">
-          <thead>
-            <tr><th>Param</th><th>Type</th><th>Required</th><th>Description</th></tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="param-name">template</td>
-              <td class="param-type">string</td>
-              <td>No</td>
-              <td class="param-desc">Template ID (default: blog-minimal-dark)</td>
-            </tr>
-            <tr>
-              <td class="param-name">title</td>
-              <td class="param-type">string</td>
-              <td><span class="param-required">Yes</span></td>
-              <td class="param-desc">Main title text</td>
-            </tr>
-            <tr>
-              <td class="param-name">description</td>
-              <td class="param-type">string</td>
-              <td>No</td>
-              <td class="param-desc">Subtitle or description</td>
-            </tr>
-            <tr>
-              <td class="param-name">author</td>
-              <td class="param-type">string</td>
-              <td>No</td>
-              <td class="param-desc">Author name</td>
-            </tr>
-            <tr>
-              <td class="param-name">bgColor</td>
-              <td class="param-type">string</td>
-              <td>No</td>
-              <td class="param-desc">Background color (hex, e.g. #0a0a0a)</td>
-            </tr>
-            <tr>
-              <td class="param-name">accentColor</td>
-              <td class="param-type">string</td>
-              <td>No</td>
-              <td class="param-desc">Accent color (hex)</td>
-            </tr>
-            <tr>
-              <td class="param-name">width</td>
-              <td class="param-type">number</td>
-              <td>No</td>
-              <td class="param-desc">Image width (200-2400, default: 1200)</td>
-            </tr>
-            <tr>
-              <td class="param-name">height</td>
-              <td class="param-type">number</td>
-              <td>No</td>
-              <td class="param-desc">Image height (200-2400, default: 630)</td>
-            </tr>
-          </tbody>
-        </table>
+        <div class="param-list">
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">template</code>
+              <span class="param-type">string</span>
+            </div>
+            <p class="param-desc">Template ID (default: <code>blog-minimal-dark</code>)</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">title</code>
+              <span class="param-type">string</span>
+              <span class="param-required">required</span>
+            </div>
+            <p class="param-desc">Main title text</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">description</code>
+              <span class="param-type">string</span>
+            </div>
+            <p class="param-desc">Subtitle or description</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">author</code>
+              <span class="param-type">string</span>
+            </div>
+            <p class="param-desc">Author name</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">bgColor</code>
+              <span class="param-type">string</span>
+            </div>
+            <p class="param-desc">Background color (hex, e.g. <code>#0a0a0a</code>)</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">accentColor</code>
+              <span class="param-type">string</span>
+            </div>
+            <p class="param-desc">Accent color (hex)</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">width</code>
+              <span class="param-type">number</span>
+            </div>
+            <p class="param-desc">Image width, 200–2400 (default: 1200)</p>
+          </div>
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">height</code>
+              <span class="param-type">number</span>
+            </div>
+            <p class="param-desc">Image height, 200–2400 (default: 630)</p>
+          </div>
+        </div>
 
         <h4>Examples</h4>
         <div class="code-block">
           <div class="code-block-header">
-            <div class="code-block-dots"><span class="code-block-dot"></span><span class="code-block-dot"></span><span class="code-block-dot"></span></div>
-            <span>curl</span>
+            <span class="code-block-lang">curl</span>
             <button class="code-block-copy" data-copy type="button">Copy</button>
           </div>
-          <pre class="code-block-body"><code>curl "https://og.codercops.com/api/og?title=Hello+World&template=blog-minimal-dark" \
+          <pre class="code-block-body"><code>curl "https://og.codercops.com/api/og?\
+title=Hello+World&\
+template=blog-minimal-dark" \
   --output og-image.png</code></pre>
         </div>
 
         <div class="code-block">
           <div class="code-block-header">
-            <div class="code-block-dots"><span class="code-block-dot"></span><span class="code-block-dot"></span><span class="code-block-dot"></span></div>
-            <span>JavaScript</span>
+            <span class="code-block-lang">JavaScript</span>
             <button class="code-block-copy" data-copy type="button">Copy</button>
           </div>
           <pre class="code-block-body"><code>{`const params = new URLSearchParams({
@@ -128,28 +130,30 @@ import '@/styles/api-docs.css';
   author: 'OGCOPS',
 });
 
-const imageUrl = \`https://og.codercops.com/api/og?\${params}\`;
+const url = \`https://og.codercops.com/api/og?\${params}\`;
 
 // Use as meta tag:
-// <meta property="og:image" content={\`\${imageUrl}\`} />`}</code></pre>
+// <meta property="og:image" content={url} />`}</code></pre>
         </div>
 
         <div class="code-block">
           <div class="code-block-header">
-            <div class="code-block-dots"><span class="code-block-dot"></span><span class="code-block-dot"></span><span class="code-block-dot"></span></div>
-            <span>Python</span>
+            <span class="code-block-lang">Python</span>
             <button class="code-block-copy" data-copy type="button">Copy</button>
           </div>
           <pre class="code-block-body"><code>{`import requests
 
-response = requests.get("https://og.codercops.com/api/og", params={
-    "template": "blog-minimal-dark",
-    "title": "Hello World",
-    "author": "OGCOPS",
-})
+resp = requests.get(
+    "https://og.codercops.com/api/og",
+    params={
+        "template": "blog-minimal-dark",
+        "title": "Hello World",
+        "author": "OGCOPS",
+    },
+)
 
 with open("og-image.png", "wb") as f:
-    f.write(response.content)`}</code></pre>
+    f.write(resp.content)`}</code></pre>
         </div>
       </div>
 
@@ -157,34 +161,29 @@ with open("og-image.png", "wb") as f:
       <div class="endpoint-card" id="preview">
         <div class="endpoint-header">
           <span class="endpoint-method">GET</span>
-          <span class="endpoint-path">/api/preview</span>
-          <a href="#preview" class="section-anchor" aria-label="Link to this section">#</a>
+          <code class="endpoint-path">/api/preview</code>
         </div>
         <p class="endpoint-desc">Fetch and analyze meta tags from a URL. Returns JSON with meta tags, analysis score, and per-platform preview data for 8 platforms.</p>
 
         <h4>Parameters</h4>
-        <table class="param-table">
-          <thead>
-            <tr><th>Param</th><th>Type</th><th>Required</th><th>Description</th></tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="param-name">url</td>
-              <td class="param-type">string</td>
-              <td><span class="param-required">Yes</span></td>
-              <td class="param-desc">URL to check (must be a valid URL)</td>
-            </tr>
-          </tbody>
-        </table>
+        <div class="param-list">
+          <div class="param-item">
+            <div class="param-head">
+              <code class="param-name">url</code>
+              <span class="param-type">string</span>
+              <span class="param-required">required</span>
+            </div>
+            <p class="param-desc">URL to check (must be a valid URL)</p>
+          </div>
+        </div>
 
         <h4>Response</h4>
-        <div class="code-block code-block-collapsible">
+        <div class="code-block">
           <div class="code-block-header">
-            <div class="code-block-dots"><span class="code-block-dot"></span><span class="code-block-dot"></span><span class="code-block-dot"></span></div>
-            <span>JSON Response</span>
+            <span class="code-block-lang">JSON Response</span>
             <button class="code-block-copy" data-copy type="button">Copy</button>
           </div>
-          <pre class="code-block-body" id="preview-response"><code>{`{
+          <pre class="code-block-body"><code>{`{
   "url": "https://example.com",
   "meta": {
     "title": "Example",
@@ -196,7 +195,7 @@ with open("og-image.png", "wb") as f:
     "score": 85,
     "grade": "B",
     "issues": [...],
-    "summary": "Good setup with minor improvements possible."
+    "summary": "Good setup."
   },
   "platforms": [
     {
@@ -217,15 +216,13 @@ with open("og-image.png", "wb") as f:
       <div class="endpoint-card" id="templates">
         <div class="endpoint-header">
           <span class="endpoint-method">GET</span>
-          <span class="endpoint-path">/api/templates</span>
-          <a href="#templates" class="section-anchor" aria-label="Link to this section">#</a>
+          <code class="endpoint-path">/api/templates</code>
         </div>
         <p class="endpoint-desc">List all available templates with their fields, defaults, and thumbnail URLs.</p>
 
         <div class="code-block">
           <div class="code-block-header">
-            <div class="code-block-dots"><span class="code-block-dot"></span><span class="code-block-dot"></span><span class="code-block-dot"></span></div>
-            <span>curl</span>
+            <span class="code-block-lang">curl</span>
             <button class="code-block-copy" data-copy type="button">Copy</button>
           </div>
           <pre class="code-block-body"><code>curl "https://og.codercops.com/api/templates"</code></pre>
@@ -236,18 +233,17 @@ with open("og-image.png", "wb") as f:
       <div class="endpoint-card" id="thumbnail">
         <div class="endpoint-header">
           <span class="endpoint-method">GET</span>
-          <span class="endpoint-path">/api/templates/&#123;id&#125;/thumbnail.png</span>
-          <a href="#thumbnail" class="section-anchor" aria-label="Link to this section">#</a>
+          <code class="endpoint-path">/api/templates/&#123;id&#125;/thumbnail.png</code>
         </div>
-        <p class="endpoint-desc">Get a 600x315 thumbnail preview of a template with its default values. Cached for 7 days.</p>
+        <p class="endpoint-desc">Get a 600×315 thumbnail preview of a template with its default values. Cached for 7 days.</p>
 
         <div class="code-block">
           <div class="code-block-header">
-            <div class="code-block-dots"><span class="code-block-dot"></span><span class="code-block-dot"></span><span class="code-block-dot"></span></div>
-            <span>Example</span>
+            <span class="code-block-lang">Example</span>
             <button class="code-block-copy" data-copy type="button">Copy</button>
           </div>
-          <pre class="code-block-body"><code>https://og.codercops.com/api/templates/blog-minimal-dark/thumbnail.png</code></pre>
+          <pre class="code-block-body"><code>https://og.codercops.com/api/templates/\
+blog-minimal-dark/thumbnail.png</code></pre>
         </div>
       </div>
     </div>
@@ -255,34 +251,29 @@ with open("og-image.png", "wb") as f:
 </Layout>
 
 <script is:inline>
-  // Copy buttons for code blocks
-  document.querySelectorAll('[data-copy]').forEach(btn => {
+  document.querySelectorAll('[data-copy]').forEach(function(btn) {
     btn.addEventListener('click', function() {
-      const codeBlock = this.closest('.code-block');
-      const code = codeBlock?.querySelector('code')?.textContent || '';
-      navigator.clipboard.writeText(code).then(() => {
-        this.textContent = 'Copied!';
-        window.showToast?.('Copied to clipboard!', 'success');
-        setTimeout(() => { this.textContent = 'Copy'; }, 2000);
+      var codeBlock = this.closest('.code-block');
+      var code = codeBlock ? (codeBlock.querySelector('code')?.textContent || '') : '';
+      navigator.clipboard.writeText(code).then(function() {
+        btn.textContent = 'Copied!';
+        if (window.showToast) window.showToast('Copied to clipboard!', 'success');
+        setTimeout(function() { btn.textContent = 'Copy'; }, 2000);
       });
     });
   });
 
-  // Sidebar active state on scroll
-  const sidebarLinks = document.querySelectorAll('.api-sidebar-link');
-  const sections = document.querySelectorAll('.endpoint-card[id]');
+  var sidebarLinks = document.querySelectorAll('.api-sidebar-link');
+  var sections = document.querySelectorAll('.endpoint-card[id]');
 
   function updateSidebar() {
-    let current = '';
-    sections.forEach(section => {
-      const rect = section.getBoundingClientRect();
-      if (rect.top <= 120) current = section.id;
+    var current = '';
+    sections.forEach(function(section) {
+      if (section.getBoundingClientRect().top <= 140) current = section.id;
     });
-    if (!current && sections.length) current = 'overview';
-
-    sidebarLinks.forEach(link => {
-      const href = link.getAttribute('href');
-      if (href === '#' + current || (!current && href === '#overview')) {
+    sidebarLinks.forEach(function(link) {
+      var href = link.getAttribute('href');
+      if (href === '#' + current) {
         link.classList.add('active');
       } else {
         link.classList.remove('active');
@@ -291,4 +282,5 @@ with open("og-image.png", "wb") as f:
   }
 
   window.addEventListener('scroll', updateSidebar, { passive: true });
+  updateSidebar();
 </script>

--- a/src/pages/api/ai/autofill.ts
+++ b/src/pages/api/ai/autofill.ts
@@ -1,0 +1,144 @@
+import type { APIRoute } from 'astro';
+import { z } from 'zod';
+import { getProvider } from '@/lib/ai/providers';
+import { fetchMetaTags } from '@/lib/meta-fetcher';
+import { buildAutofillPrompt, parseAutofillResponse } from '@/lib/ai/autofill';
+import { getTemplate } from '@/templates/registry';
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Content-Type': 'application/json',
+};
+
+const autofillSchema = z.object({
+  provider: z.enum(['openai', 'anthropic', 'google', 'groq', 'openrouter']),
+  apiKey: z.string().min(1),
+  model: z.string().min(1),
+  url: z.string().url('A valid URL is required'),
+});
+
+export const POST: APIRoute = async ({ request }) => {
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(
+      JSON.stringify({ error: 'Invalid JSON body' }),
+      { status: 400, headers: CORS_HEADERS }
+    );
+  }
+
+  const parsed = autofillSchema.safeParse(body);
+  if (!parsed.success) {
+    const errors = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+    return new Response(
+      JSON.stringify({ error: errors }),
+      { status: 400, headers: CORS_HEADERS }
+    );
+  }
+
+  const { provider: providerId, apiKey, model, url } = parsed.data;
+  const provider = getProvider(providerId);
+  if (!provider) {
+    return new Response(
+      JSON.stringify({ error: `Unknown provider: ${providerId}` }),
+      { status: 400, headers: CORS_HEADERS }
+    );
+  }
+
+  try {
+    // Step 1: Fetch the URL and extract content
+    let pageContent: {
+      title?: string;
+      description?: string;
+      headings?: string[];
+      bodyText?: string;
+      ogTags?: Record<string, string>;
+      themeColor?: string;
+    };
+
+    try {
+      const meta = await fetchMetaTags(url);
+      pageContent = {
+        title: meta.ogTitle || meta.title,
+        description: meta.ogDescription || meta.description,
+        ogTags: meta as Record<string, string>,
+        themeColor: meta.themeColor,
+      };
+    } catch {
+      return new Response(
+        JSON.stringify({ error: 'Could not fetch the URL' }),
+        { status: 502, headers: CORS_HEADERS }
+      );
+    }
+
+    // Step 2: Build prompt and call AI
+    const { prompt, systemPrompt } = buildAutofillPrompt(pageContent);
+    const { url: aiUrl, body: aiBody } = provider.bodyFormatter({
+      model,
+      prompt,
+      systemPrompt,
+      maxTokens: 500,
+      temperature: 0.5,
+    });
+
+    const fetchUrl = providerId === 'google' ? `${aiUrl}?key=${apiKey}` : aiUrl;
+    const headers = provider.headerBuilder(apiKey);
+
+    const aiResponse = await fetch(fetchUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(aiBody),
+      signal: AbortSignal.timeout(30000),
+    });
+
+    if (!aiResponse.ok) {
+      if (aiResponse.status === 401 || aiResponse.status === 403) {
+        return new Response(
+          JSON.stringify({ error: 'Invalid API key' }),
+          { status: 401, headers: CORS_HEADERS }
+        );
+      }
+      return new Response(
+        JSON.stringify({ error: `AI provider error (${aiResponse.status})` }),
+        { status: 502, headers: CORS_HEADERS }
+      );
+    }
+
+    const aiData = await aiResponse.json();
+    const aiResult = provider.responseParser(aiData);
+
+    // Step 3: Parse the autofill result
+    const autofill = parseAutofillResponse(aiResult.content);
+    if (!autofill) {
+      return new Response(
+        JSON.stringify({ error: 'Could not parse AI response' }),
+        { status: 502, headers: CORS_HEADERS }
+      );
+    }
+
+    // Validate template exists
+    const template = getTemplate(autofill.templateId);
+    if (!template) {
+      // Fallback to first template in the suggested category
+      autofill.templateId = 'blog-minimal-dark';
+    }
+
+    return new Response(JSON.stringify(autofill), {
+      status: 200,
+      headers: CORS_HEADERS,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Autofill failed';
+    return new Response(
+      JSON.stringify({ error: message }),
+      { status: 502, headers: CORS_HEADERS }
+    );
+  }
+};

--- a/src/pages/api/ai/generate.ts
+++ b/src/pages/api/ai/generate.ts
@@ -1,0 +1,106 @@
+import type { APIRoute } from 'astro';
+import { aiGenerateSchema } from '@/lib/ai/validation';
+import { getProvider } from '@/lib/ai/providers';
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Content-Type': 'application/json',
+};
+
+export const POST: APIRoute = async ({ request }) => {
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(
+      JSON.stringify({ error: 'Invalid JSON body' }),
+      { status: 400, headers: CORS_HEADERS }
+    );
+  }
+
+  const parsed = aiGenerateSchema.safeParse(body);
+  if (!parsed.success) {
+    const errors = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+    return new Response(
+      JSON.stringify({ error: errors }),
+      { status: 400, headers: CORS_HEADERS }
+    );
+  }
+
+  const { provider: providerId, apiKey, model, prompt, systemPrompt, maxTokens, temperature } = parsed.data;
+  const provider = getProvider(providerId);
+  if (!provider) {
+    return new Response(
+      JSON.stringify({ error: `Unknown provider: ${providerId}` }),
+      { status: 400, headers: CORS_HEADERS }
+    );
+  }
+
+  try {
+    const { url, body: requestBody } = provider.bodyFormatter({
+      model,
+      prompt,
+      systemPrompt,
+      maxTokens,
+      temperature,
+    });
+
+    // Google passes API key as query param
+    const fetchUrl = providerId === 'google' ? `${url}?key=${apiKey}` : url;
+    const headers = provider.headerBuilder(apiKey);
+
+    const response = await fetch(fetchUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(requestBody),
+      signal: AbortSignal.timeout(30000),
+    });
+
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
+        return new Response(
+          JSON.stringify({ error: 'Invalid API key' }),
+          { status: 401, headers: CORS_HEADERS }
+        );
+      }
+      if (response.status === 429) {
+        return new Response(
+          JSON.stringify({ error: 'Rate limited by provider' }),
+          { status: 429, headers: CORS_HEADERS }
+        );
+      }
+
+      let errorMessage = `Provider error (${response.status})`;
+      try {
+        const errBody = await response.json();
+        errorMessage = errBody.error?.message ?? errBody.error ?? errorMessage;
+      } catch {
+        // use default error message
+      }
+      return new Response(
+        JSON.stringify({ error: errorMessage }),
+        { status: 502, headers: CORS_HEADERS }
+      );
+    }
+
+    const data = await response.json();
+    const result = provider.responseParser(data);
+
+    return new Response(JSON.stringify(result), {
+      status: 200,
+      headers: CORS_HEADERS,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Generation failed';
+    return new Response(
+      JSON.stringify({ error: message }),
+      { status: 502, headers: CORS_HEADERS }
+    );
+  }
+};

--- a/src/pages/api/ai/validate.ts
+++ b/src/pages/api/ai/validate.ts
@@ -1,0 +1,92 @@
+import type { APIRoute } from 'astro';
+import { aiValidateSchema } from '@/lib/ai/validation';
+import { getProvider } from '@/lib/ai/providers';
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Content-Type': 'application/json',
+};
+
+export const POST: APIRoute = async ({ request }) => {
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(
+      JSON.stringify({ valid: false, error: 'Invalid JSON body' }),
+      { status: 400, headers: CORS_HEADERS }
+    );
+  }
+
+  const parsed = aiValidateSchema.safeParse(body);
+  if (!parsed.success) {
+    const errors = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+    return new Response(
+      JSON.stringify({ valid: false, error: errors }),
+      { status: 400, headers: CORS_HEADERS }
+    );
+  }
+
+  const { provider: providerId, apiKey } = parsed.data;
+  const provider = getProvider(providerId);
+  if (!provider) {
+    return new Response(
+      JSON.stringify({ valid: false, error: `Unknown provider: ${providerId}` }),
+      { status: 400, headers: CORS_HEADERS }
+    );
+  }
+
+  try {
+    const validateReq = provider.validateRequest(apiKey);
+
+    // For Anthropic, validation needs a minimal message body
+    const fetchOptions: RequestInit = {
+      method: validateReq.method,
+      headers: validateReq.headers,
+      signal: AbortSignal.timeout(10000),
+    };
+
+    if (providerId === 'anthropic') {
+      fetchOptions.method = 'POST';
+      fetchOptions.body = JSON.stringify({
+        model: provider.models[0].id,
+        max_tokens: 1,
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+    }
+
+    const response = await fetch(validateReq.url, fetchOptions);
+
+    if (response.ok) {
+      return new Response(
+        JSON.stringify({ valid: true }),
+        { status: 200, headers: CORS_HEADERS }
+      );
+    }
+
+    // 401/403 = invalid key, other errors = provider issue
+    if (response.status === 401 || response.status === 403) {
+      return new Response(
+        JSON.stringify({ valid: false, error: 'Invalid API key' }),
+        { status: 200, headers: CORS_HEADERS }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({ valid: false, error: `Provider returned ${response.status}` }),
+      { status: 200, headers: CORS_HEADERS }
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Validation failed';
+    return new Response(
+      JSON.stringify({ valid: false, error: message }),
+      { status: 502, headers: CORS_HEADERS }
+    );
+  }
+};

--- a/src/pages/create/[category].astro
+++ b/src/pages/create/[category].astro
@@ -4,6 +4,7 @@ import { EditorApp } from '@/components/editor/EditorApp';
 import { ALL_CATEGORIES, CATEGORY_META } from '@/templates/types';
 import type { TemplateCategory } from '@/templates/types';
 import '@/styles/editor.css';
+import '@/styles/ai.css';
 
 const { category } = Astro.params;
 

--- a/src/pages/create/index.astro
+++ b/src/pages/create/index.astro
@@ -2,6 +2,7 @@
 import ToolLayout from '@/layouts/ToolLayout.astro';
 import { EditorApp } from '@/components/editor/EditorApp';
 import '@/styles/editor.css';
+import '@/styles/ai.css';
 ---
 
 <ToolLayout title="Create OG Image" description="Design beautiful OG images with 120+ templates. Free, no login required.">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,7 +14,7 @@ const categoryCounts = getCategoryCounts();
     <div class="hero-glow"></div>
     <div class="hero-pattern"></div>
     <div class="container hero-inner">
-      <div class="hero-content" data-animate="slide-up">
+      <div class="hero-text" data-animate="slide-up">
         <span class="section-label">Free & Open Source</span>
         <h1><span class="text-gradient">Free</span> OG Image<br />Generator</h1>
         <p class="hero-subtitle">
@@ -26,6 +26,56 @@ const categoryCounts = getCategoryCounts();
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
           </a>
           <a href="/preview" class="btn btn-outline btn-lg">Check Your URL</a>
+        </div>
+        <div class="hero-support">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="var(--accent-primary)" stroke="none"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span>Support this project</span>
+          <a href="https://buymeacoffee.com/codercops" target="_blank" rel="noopener" class="hero-support-link">Buy Me a Coffee</a>
+          <span class="hero-support-dot">&middot;</span>
+          <a href="https://www.paypal.com/paypalme/codercops" target="_blank" rel="noopener" class="hero-support-link">PayPal</a>
+        </div>
+      </div>
+      <div class="hero-visual" data-animate="slide-up" data-animate-delay="2">
+        <div class="og-card-stack">
+          <!-- Card 1 — back (dark template) -->
+          <div class="og-card og-card-1">
+            <div class="og-card-img og-card-img-dark">
+              <span class="og-card-accent-line"></span>
+              <span class="og-card-tag">BLOG</span>
+              <span class="og-card-title-lg">How to Build<br/>a REST API</span>
+            </div>
+            <div class="og-card-meta">
+              <span class="og-card-favicon og-card-favicon-dark"></span>
+              <span>dev.to &middot; 5 min read</span>
+            </div>
+          </div>
+          <!-- Card 2 — middle (coral gradient) -->
+          <div class="og-card og-card-2">
+            <div class="og-card-img og-card-img-coral">
+              <span class="og-card-tag-light">LAUNCH</span>
+              <span class="og-card-title-lg og-card-title-white">Introducing<br/>OGCOPS 2.0</span>
+              <span class="og-card-subtitle-light">Free &middot; Open Source &middot; No Login</span>
+            </div>
+            <div class="og-card-meta">
+              <span class="og-card-favicon og-card-favicon-coral"></span>
+              <span>og.codercops.com</span>
+            </div>
+          </div>
+          <!-- Card 3 — front (light/clean) -->
+          <div class="og-card og-card-3">
+            <div class="og-card-img og-card-img-light">
+              <span class="og-card-tag-dark">PORTFOLIO</span>
+              <span class="og-card-title-lg og-card-title-dark">Sarah Chen<br/>Software Engineer</span>
+            </div>
+            <div class="og-card-meta">
+              <span class="og-card-favicon og-card-favicon-blue"></span>
+              <span>github.com/sarahchen</span>
+            </div>
+          </div>
+          <!-- Floating platform pills -->
+          <span class="platform-pill pill-twitter">Twitter</span>
+          <span class="platform-pill pill-linkedin">LinkedIn</span>
+          <span class="platform-pill pill-discord">Discord</span>
         </div>
       </div>
     </div>
@@ -205,6 +255,14 @@ const categoryCounts = getCategoryCounts();
             Star on GitHub
           </a>
           <a href="/templates" class="btn btn-outline btn-lg">Browse Templates</a>
+          <a href="https://buymeacoffee.com/codercops" class="btn btn-bmc btn-lg" target="_blank" rel="noopener">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 8h1a4 4 0 1 1 0 8h-1"/><path d="M3 8h14v9a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4Z"/><line x1="6" x2="6" y1="2" y2="4"/><line x1="10" x2="10" y1="2" y2="4"/><line x1="14" x2="14" y1="2" y2="4"/></svg>
+            Buy Me a Coffee
+          </a>
+          <a href="https://www.paypal.com/paypalme/codercops" class="btn btn-paypal btn-lg" target="_blank" rel="noopener">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="14" x="2" y="5" rx="2"/><line x1="2" x2="22" y1="10" y2="10"/></svg>
+            PayPal
+          </a>
         </div>
       </div>
     </div>
@@ -225,18 +283,17 @@ const categoryCounts = getCategoryCounts();
 </script>
 
 <style>
-  /* Hero */
+  /* Hero — split layout */
   .hero {
     position: relative;
     padding: var(--space-5xl) 0 var(--space-4xl);
-    text-align: center;
     overflow: hidden;
   }
 
   .hero-glow {
     position: absolute;
     top: -120px;
-    left: 50%;
+    left: 30%;
     transform: translateX(-50%);
     width: 800px;
     height: 500px;
@@ -257,7 +314,18 @@ const categoryCounts = getCategoryCounts();
     -webkit-mask-image: radial-gradient(ellipse 60% 50% at 50% 40%, black 20%, transparent 70%);
   }
 
-  .hero-inner { position: relative; z-index: 1; }
+  .hero-inner {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    gap: var(--space-3xl);
+  }
+
+  .hero-text {
+    flex: 1;
+    min-width: 0;
+  }
 
   .hero h1 {
     font-size: var(--text-7xl);
@@ -270,15 +338,242 @@ const categoryCounts = getCategoryCounts();
     font-size: var(--text-xl);
     color: var(--text-muted);
     max-width: 500px;
-    margin: 0 auto var(--space-xl);
+    margin: 0 0 var(--space-xl);
     line-height: 1.6;
   }
 
   .hero-ctas {
     display: flex;
     gap: var(--space-md);
-    justify-content: center;
     flex-wrap: wrap;
+  }
+
+  /* Support line below CTAs */
+  .hero-support {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    margin-top: var(--space-xl);
+    font-size: var(--text-sm);
+    color: var(--text-subtle);
+  }
+
+  .hero-support span {
+    color: var(--text-subtle);
+  }
+
+  .hero-support-link {
+    color: var(--text-muted);
+    font-weight: 500;
+    text-decoration: none;
+    transition: color var(--transition);
+  }
+
+  .hero-support-link:hover {
+    color: var(--accent-primary);
+  }
+
+  .hero-support-dot {
+    color: var(--border-strong);
+  }
+
+  /* Hero visual — card stack */
+  .hero-visual {
+    display: none;
+    flex: 1;
+    min-width: 0;
+    position: relative;
+    height: 420px;
+  }
+
+  .og-card-stack {
+    position: relative;
+    width: 100%;
+    height: 100%;
+  }
+
+  .og-card {
+    position: absolute;
+    width: 320px;
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    box-shadow: var(--shadow-lg);
+    transition: transform var(--transition-slow), box-shadow var(--transition-slow);
+    border: 1px solid var(--border);
+  }
+
+  .og-card:hover {
+    box-shadow: var(--shadow-xl);
+  }
+
+  .og-card-1 {
+    top: 30px;
+    left: 0;
+    transform: rotate(-6deg);
+    z-index: 1;
+  }
+  .og-card-1:hover { transform: rotate(-6deg) translateY(-4px); }
+
+  .og-card-2 {
+    top: 10px;
+    left: 80px;
+    transform: rotate(3deg);
+    z-index: 2;
+  }
+  .og-card-2:hover { transform: rotate(3deg) translateY(-4px); }
+
+  .og-card-3 {
+    top: 60px;
+    left: 140px;
+    transform: rotate(-1deg);
+    z-index: 3;
+  }
+  .og-card-3:hover { transform: rotate(-1deg) translateY(-4px); }
+
+  /* OG card image area (1200:630 ratio ~ 1.9:1) */
+  .og-card-img {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 1200 / 630;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    padding: 20px;
+    overflow: hidden;
+  }
+
+  .og-card-img-dark {
+    background: linear-gradient(145deg, #1a1a1a, #2a2a2a);
+  }
+
+  .og-card-img-coral {
+    background: var(--gradient-coral);
+  }
+
+  .og-card-img-light {
+    background: linear-gradient(145deg, #f8f8f8, #ffffff);
+  }
+
+  .og-card-accent-line {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: var(--gradient-coral);
+  }
+
+  .og-card-tag,
+  .og-card-tag-light,
+  .og-card-tag-dark {
+    display: inline-block;
+    width: fit-content;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    padding: 3px 8px;
+    border-radius: 4px;
+    margin-bottom: 8px;
+  }
+
+  .og-card-tag {
+    background: var(--accent-primary);
+    color: #fff;
+  }
+  .og-card-tag-light {
+    background: rgba(255, 255, 255, 0.2);
+    color: rgba(255, 255, 255, 0.9);
+  }
+  .og-card-tag-dark {
+    background: rgba(0, 0, 0, 0.08);
+    color: var(--text-muted);
+  }
+
+  .og-card-title-lg {
+    font-family: var(--font-sans);
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 1.2;
+    color: #fff;
+  }
+
+  .og-card-title-white {
+    color: #fff;
+  }
+
+  .og-card-title-dark {
+    color: var(--text);
+  }
+
+  .og-card-subtitle-light {
+    font-size: 10px;
+    color: rgba(255, 255, 255, 0.7);
+    margin-top: 6px;
+  }
+
+  .og-card-meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    font-size: 11px;
+    color: var(--text-muted);
+    background: var(--bg-elevated);
+    border-top: 1px solid var(--border-muted);
+  }
+
+  .og-card-favicon {
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    flex-shrink: 0;
+  }
+  .og-card-favicon-dark { background: #333; }
+  .og-card-favicon-coral { background: var(--accent-primary); }
+  .og-card-favicon-blue { background: #0969da; }
+
+  /* Floating platform pills */
+  .platform-pill {
+    position: absolute;
+    padding: 4px 10px;
+    font-size: 10px;
+    font-weight: 600;
+    border-radius: var(--radius-full);
+    color: #fff;
+    box-shadow: var(--shadow-md);
+    z-index: 4;
+    pointer-events: none;
+    animation: pill-float 4s ease-in-out infinite;
+  }
+
+  .pill-twitter {
+    top: 0;
+    right: 20px;
+    background: #1DA1F2;
+    animation-delay: 0s;
+  }
+  .pill-linkedin {
+    bottom: 40px;
+    left: 10px;
+    background: #0A66C2;
+    animation-delay: 1.3s;
+  }
+  .pill-discord {
+    bottom: 10px;
+    right: 60px;
+    background: #5865F2;
+    animation-delay: 2.6s;
+  }
+
+  @keyframes pill-float {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-8px); }
+  }
+
+  @media (min-width: 1024px) {
+    .hero-visual {
+      display: block;
+    }
   }
 
   /* Bento Grid */
@@ -572,6 +867,32 @@ const categoryCounts = getCategoryCounts();
     gap: var(--space-md);
     justify-content: center;
     margin-top: var(--space-xl);
+    flex-wrap: wrap;
+  }
+
+  /* Branded support buttons */
+  .btn-bmc {
+    background: #FFDD00;
+    color: #000;
+    border: 1px solid #FFDD00;
+    font-weight: 600;
+  }
+  .btn-bmc:hover {
+    background: #e6c800;
+    border-color: #e6c800;
+    box-shadow: 0 4px 16px rgba(255, 221, 0, 0.3);
+  }
+
+  .btn-paypal {
+    background: #0070BA;
+    color: #fff;
+    border: 1px solid #0070BA;
+    font-weight: 600;
+  }
+  .btn-paypal:hover {
+    background: #005ea6;
+    border-color: #005ea6;
+    box-shadow: 0 4px 16px rgba(0, 112, 186, 0.3);
   }
 
   @media (max-width: 1024px) {
@@ -579,10 +900,13 @@ const categoryCounts = getCategoryCounts();
   }
 
   @media (max-width: 768px) {
+    .hero { text-align: center; }
     .hero h1 { font-size: var(--text-4xl); }
-    .hero-glow { width: 400px; height: 300px; }
+    .hero-glow { width: 400px; height: 300px; left: 50%; }
+    .hero-subtitle { margin-left: auto; margin-right: auto; }
+    .hero-ctas { justify-content: center; flex-direction: column; align-items: center; }
+    .hero-support { justify-content: center; flex-wrap: wrap; }
     .api-teaser { grid-template-columns: 1fr; }
-    .hero-ctas { flex-direction: column; align-items: center; }
     .bento-grid { grid-template-columns: 1fr; }
     .features-grid { grid-template-columns: 1fr; }
     .timeline-line { left: 20px; }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -37,39 +37,52 @@ const categoryCounts = getCategoryCounts();
       </div>
       <div class="hero-visual" data-animate="slide-up" data-animate-delay="2">
         <div class="og-card-stack">
-          <!-- Card 1 — back (dark template) -->
+          <!-- Card 1 — back (blog template) -->
           <div class="og-card og-card-1">
-            <div class="og-card-img og-card-img-dark">
-              <span class="og-card-accent-line"></span>
-              <span class="og-card-tag">BLOG</span>
-              <span class="og-card-title-lg">How to Build<br/>a REST API</span>
-            </div>
+            <img
+              src="/api/templates/blog-minimal-dark/thumbnail.png"
+              alt="Blog Minimal Dark template"
+              class="og-card-img-real"
+              loading="eager"
+              width="600"
+              height="315"
+            />
             <div class="og-card-meta">
               <span class="og-card-favicon og-card-favicon-dark"></span>
-              <span>dev.to &middot; 5 min read</span>
+              <span class="og-card-meta-text">blog-minimal-dark</span>
+              <span class="og-card-meta-badge">Blog</span>
             </div>
           </div>
-          <!-- Card 2 — middle (coral gradient) -->
+          <!-- Card 2 — middle (product template) -->
           <div class="og-card og-card-2">
-            <div class="og-card-img og-card-img-coral">
-              <span class="og-card-tag-light">LAUNCH</span>
-              <span class="og-card-title-lg og-card-title-white">Introducing<br/>OGCOPS 2.0</span>
-              <span class="og-card-subtitle-light">Free &middot; Open Source &middot; No Login</span>
-            </div>
+            <img
+              src="/api/templates/product-gradient-wave/thumbnail.png"
+              alt="Product Gradient Wave template"
+              class="og-card-img-real"
+              loading="eager"
+              width="600"
+              height="315"
+            />
             <div class="og-card-meta">
               <span class="og-card-favicon og-card-favicon-coral"></span>
-              <span>og.codercops.com</span>
+              <span class="og-card-meta-text">product-gradient-wave</span>
+              <span class="og-card-meta-badge">Product</span>
             </div>
           </div>
-          <!-- Card 3 — front (light/clean) -->
+          <!-- Card 3 — front (event template) -->
           <div class="og-card og-card-3">
-            <div class="og-card-img og-card-img-light">
-              <span class="og-card-tag-dark">PORTFOLIO</span>
-              <span class="og-card-title-lg og-card-title-dark">Sarah Chen<br/>Software Engineer</span>
-            </div>
+            <img
+              src="/api/templates/event-hackathon/thumbnail.png"
+              alt="Event Hackathon template"
+              class="og-card-img-real"
+              loading="eager"
+              width="600"
+              height="315"
+            />
             <div class="og-card-meta">
               <span class="og-card-favicon og-card-favicon-blue"></span>
-              <span>github.com/sarahchen</span>
+              <span class="og-card-meta-text">event-hackathon</span>
+              <span class="og-card-meta-badge">Event</span>
             </div>
           </div>
           <!-- Floating platform pills -->
@@ -398,12 +411,14 @@ const categoryCounts = getCategoryCounts();
     border-radius: var(--radius-lg);
     overflow: hidden;
     box-shadow: var(--shadow-lg);
-    transition: transform var(--transition-slow), box-shadow var(--transition-slow);
-    border: 1px solid var(--border);
+    transition: transform var(--transition-slow), box-shadow var(--transition-slow), border-color var(--transition-slow);
+    border: 1.5px solid var(--border);
+    background: var(--bg-elevated);
   }
 
   .og-card:hover {
     box-shadow: var(--shadow-xl);
+    border-color: var(--accent-primary);
   }
 
   .og-card-1 {
@@ -430,85 +445,14 @@ const categoryCounts = getCategoryCounts();
   }
   .og-card-3:hover { transform: rotate(-1deg) translateY(-4px); }
 
-  /* OG card image area (1200:630 ratio ~ 1.9:1) */
-  .og-card-img {
-    position: relative;
+  /* OG card — real template thumbnail */
+  .og-card-img-real {
+    display: block;
     width: 100%;
+    height: auto;
     aspect-ratio: 1200 / 630;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
-    padding: 20px;
-    overflow: hidden;
-  }
-
-  .og-card-img-dark {
-    background: linear-gradient(145deg, #1a1a1a, #2a2a2a);
-  }
-
-  .og-card-img-coral {
-    background: var(--gradient-coral);
-  }
-
-  .og-card-img-light {
-    background: linear-gradient(145deg, #f8f8f8, #ffffff);
-  }
-
-  .og-card-accent-line {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 3px;
-    background: var(--gradient-coral);
-  }
-
-  .og-card-tag,
-  .og-card-tag-light,
-  .og-card-tag-dark {
-    display: inline-block;
-    width: fit-content;
-    font-size: 9px;
-    font-weight: 700;
-    letter-spacing: 0.1em;
-    padding: 3px 8px;
-    border-radius: 4px;
-    margin-bottom: 8px;
-  }
-
-  .og-card-tag {
-    background: var(--accent-primary);
-    color: #fff;
-  }
-  .og-card-tag-light {
-    background: rgba(255, 255, 255, 0.2);
-    color: rgba(255, 255, 255, 0.9);
-  }
-  .og-card-tag-dark {
-    background: rgba(0, 0, 0, 0.08);
-    color: var(--text-muted);
-  }
-
-  .og-card-title-lg {
-    font-family: var(--font-sans);
-    font-size: 16px;
-    font-weight: 700;
-    line-height: 1.2;
-    color: #fff;
-  }
-
-  .og-card-title-white {
-    color: #fff;
-  }
-
-  .og-card-title-dark {
-    color: var(--text);
-  }
-
-  .og-card-subtitle-light {
-    font-size: 10px;
-    color: rgba(255, 255, 255, 0.7);
-    margin-top: 6px;
+    object-fit: cover;
+    border-bottom: 1px solid var(--border-muted);
   }
 
   .og-card-meta {
@@ -519,7 +463,28 @@ const categoryCounts = getCategoryCounts();
     font-size: 11px;
     color: var(--text-muted);
     background: var(--bg-elevated);
-    border-top: 1px solid var(--border-muted);
+  }
+
+  .og-card-meta-text {
+    flex: 1;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-subtle);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .og-card-meta-badge {
+    font-size: 9px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 2px 7px;
+    border-radius: var(--radius-sm);
+    background: var(--accent-primary-subtle);
+    color: var(--accent-primary);
+    flex-shrink: 0;
   }
 
   .og-card-favicon {

--- a/src/pages/preview.astro
+++ b/src/pages/preview.astro
@@ -2,6 +2,7 @@
 import Layout from '@/layouts/Layout.astro';
 import { PreviewApp } from '@/components/preview/PreviewApp';
 import '@/styles/preview.css';
+import '@/styles/ai.css';
 ---
 
 <Layout title="Social Media Preview Checker" description="Check how your URL looks across Twitter, Facebook, LinkedIn, Discord, Slack, Reddit, WhatsApp, and Google Search. Free, no login.">

--- a/src/styles/ai.css
+++ b/src/styles/ai.css
@@ -1,0 +1,959 @@
+/* ===== AI Settings Modal ===== */
+.ai-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-md);
+  animation: fadeIn 0.15s ease-out;
+}
+
+.ai-modal {
+  background: var(--bg-elevated);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-xl);
+  width: 100%;
+  max-width: 480px;
+  max-height: 90vh;
+  overflow-y: auto;
+  animation: slideUp 0.2s var(--ease-out);
+}
+
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.ai-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-md) var(--space-lg);
+  border-bottom: 1px solid var(--border);
+}
+
+.ai-modal-title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.ai-modal-close {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: background var(--transition), color var(--transition);
+}
+
+.ai-modal-close:hover {
+  background: var(--bg-surface);
+  color: var(--text);
+}
+
+.ai-modal-body {
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.ai-modal-footer {
+  padding: var(--space-md) var(--space-lg);
+  border-top: 1px solid var(--border);
+  font-size: var(--text-xs);
+  color: var(--text-subtle);
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  line-height: 1.4;
+}
+
+/* ===== AI Fields ===== */
+.ai-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ai-field-label {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+/* ===== Provider Grid ===== */
+.ai-provider-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.ai-provider-btn {
+  flex: 1;
+  min-width: 80px;
+  padding: 8px 12px;
+  font-size: var(--text-xs);
+  font-weight: 500;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all var(--transition);
+  white-space: nowrap;
+}
+
+.ai-provider-btn:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.ai-provider-btn.active {
+  background: var(--accent-primary-subtle);
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+  font-weight: 600;
+}
+
+/* ===== API Key Input ===== */
+.ai-key-row {
+  display: flex;
+  gap: var(--space-sm);
+}
+
+.ai-key-input {
+  flex: 1;
+  padding: 8px 12px;
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  outline: none;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.ai-key-input:focus {
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 3px var(--accent-primary-subtle);
+}
+
+.ai-key-toggle {
+  width: 38px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: all var(--transition);
+}
+
+.ai-key-toggle:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.ai-key-link {
+  font-size: var(--text-xs);
+  color: var(--accent-primary);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  transition: opacity var(--transition);
+}
+
+.ai-key-link:hover {
+  opacity: 0.8;
+}
+
+/* ===== Model Select ===== */
+.ai-model-select {
+  width: 100%;
+  padding: 8px 32px 8px 12px;
+  font-size: var(--text-sm);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  outline: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' stroke='%23999' stroke-width='2'%3E%3Cpath d='M2 4l4 4 4-4'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  cursor: pointer;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.ai-model-select:focus {
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 3px var(--accent-primary-subtle);
+}
+
+/* ===== Action Buttons ===== */
+.ai-actions {
+  display: flex;
+  gap: var(--space-sm);
+}
+
+.ai-btn {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 16px;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: all var(--transition);
+  border: 1px solid transparent;
+  min-height: 38px;
+}
+
+.ai-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ai-btn:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+.ai-btn-validate {
+  background: var(--gradient-coral);
+  color: white;
+  border-color: var(--accent-primary);
+}
+
+.ai-btn-validate:hover:not(:disabled) {
+  box-shadow: var(--shadow-md), var(--shadow-glow);
+}
+
+.ai-btn-clear {
+  background: var(--bg-surface);
+  color: var(--text-muted);
+  border-color: var(--border);
+}
+
+.ai-btn-clear:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+
+/* ===== Spinner ===== */
+.ai-spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ===== Status ===== */
+.ai-status {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: 8px 12px;
+  font-size: var(--text-xs);
+  border-radius: var(--radius-sm);
+  font-weight: 500;
+}
+
+.ai-status-valid {
+  background: rgba(34, 197, 94, 0.1);
+  color: #16a34a;
+}
+
+.ai-status-invalid,
+.ai-status-error {
+  background: rgba(239, 68, 68, 0.1);
+  color: #dc2626;
+}
+
+/* ===== AI Generate Button (inline next to text fields) ===== */
+.ai-generate-wrapper {
+  position: relative;
+}
+
+.ai-generate-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  background: var(--accent-primary-subtle);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--accent-primary);
+  cursor: pointer;
+  transition: all var(--transition);
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+.ai-generate-btn:hover {
+  background: var(--accent-primary);
+  color: white;
+  box-shadow: var(--shadow-glow);
+}
+
+.ai-generate-btn:active {
+  transform: scale(0.95);
+}
+
+.ai-generate-btn.error {
+  border-color: #dc2626;
+  color: #dc2626;
+  background: rgba(239, 68, 68, 0.08);
+}
+
+.ai-generate-error {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  padding: 4px 8px;
+  font-size: 10px;
+  color: #dc2626;
+  background: rgba(239, 68, 68, 0.08);
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+  z-index: 10;
+  animation: fadeIn 0.15s ease-out;
+}
+
+/* ===== Spinner (dark variant for inline use) ===== */
+.ai-spinner-dark {
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent-primary);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+/* ===== Suggestion Picker ===== */
+.ai-picker {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 6px;
+  width: 320px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xl);
+  z-index: 100;
+  animation: slideUp 0.15s var(--ease-out);
+  overflow: hidden;
+}
+
+.ai-picker-header {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-muted);
+}
+
+.ai-picker-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ai-picker-list {
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.ai-picker-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  padding: var(--space-lg);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.ai-picker-option {
+  display: block;
+  width: 100%;
+  padding: 10px 12px;
+  font-size: var(--text-sm);
+  color: var(--text);
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  line-height: 1.4;
+}
+
+.ai-picker-option:hover,
+.ai-picker-option.active {
+  background: var(--accent-primary-subtle);
+}
+
+.ai-picker-option + .ai-picker-option {
+  border-top: 1px solid var(--border-muted);
+}
+
+.ai-picker-footer {
+  display: flex;
+  gap: var(--space-sm);
+  padding: 8px 12px;
+  border-top: 1px solid var(--border-muted);
+}
+
+.ai-picker-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 500;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.ai-picker-btn:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.ai-picker-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ===== Topbar AI Button ===== */
+.ai-topbar-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: var(--text-xs);
+  font-weight: 500;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-subtle);
+  cursor: pointer;
+  transition: all var(--transition);
+  white-space: nowrap;
+}
+
+.ai-topbar-btn:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.ai-topbar-btn.configured {
+  border-color: var(--accent-primary-muted);
+  color: var(--accent-primary);
+  background: var(--accent-primary-subtle);
+}
+
+.ai-topbar-btn.configured:hover {
+  box-shadow: var(--shadow-glow);
+}
+
+/* ===== Smart Autofill ===== */
+.ai-autofill-trigger {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 10px var(--space-lg);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  background: var(--accent-primary-subtle);
+  border: none;
+  border-bottom: 1px solid var(--border);
+  color: var(--accent-primary);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.ai-autofill-trigger:hover {
+  background: rgba(224, 122, 95, 0.15);
+}
+
+.ai-autofill {
+  padding: var(--space-md) var(--space-lg);
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+}
+
+.ai-autofill-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.ai-autofill-title {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--accent-primary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ai-autofill-close {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--text-subtle);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+}
+
+.ai-autofill-close:hover { color: var(--text); }
+
+.ai-autofill-desc {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  margin-bottom: var(--space-sm);
+}
+
+.ai-autofill-input-row {
+  display: flex;
+  gap: var(--space-sm);
+}
+
+.ai-autofill-input {
+  flex: 1;
+  padding: 8px 12px;
+  font-size: var(--text-sm);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  outline: none;
+  transition: border-color var(--transition);
+}
+
+.ai-autofill-input:focus {
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 3px var(--accent-primary-subtle);
+}
+
+.ai-autofill-steps {
+  margin-top: var(--space-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ai-autofill-step {
+  font-size: 11px;
+  color: var(--text-subtle);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ai-autofill-step.active { color: var(--text-muted); }
+.ai-autofill-step.done { color: #16a34a; }
+
+/* ===== AI Analyzer (Preview Checker) ===== */
+.ai-analyzer {
+  margin-top: var(--space-md);
+}
+
+.ai-analyzer-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 20px;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  background: var(--gradient-coral);
+  color: white;
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.ai-analyzer-btn:hover:not(:disabled) {
+  box-shadow: var(--shadow-md), var(--shadow-glow);
+}
+
+.ai-analyzer-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+
+.ai-analyzer-error {
+  margin-top: var(--space-sm);
+  padding: 8px 12px;
+  font-size: var(--text-xs);
+  color: #dc2626;
+  background: rgba(239, 68, 68, 0.08);
+  border-radius: var(--radius-sm);
+}
+
+.ai-analyzer-results {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.ai-analyzer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-md) var(--space-lg);
+  border-bottom: 1px solid var(--border-muted);
+}
+
+.ai-analyzer-title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+}
+
+.ai-analyzer-score {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.ai-analyzer-score-num {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  font-family: var(--font-mono);
+  color: var(--text);
+}
+
+.ai-analyzer-score-bar {
+  width: 80px;
+  height: 6px;
+  background: var(--border);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.ai-analyzer-score-fill {
+  height: 100%;
+  background: var(--gradient-coral);
+  border-radius: 3px;
+  transition: width 0.5s var(--ease-out);
+}
+
+.ai-analyzer-section {
+  padding: var(--space-md) var(--space-lg);
+  border-bottom: 1px solid var(--border-muted);
+}
+
+.ai-analyzer-section:last-of-type { border-bottom: none; }
+
+.ai-analyzer-section-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin: 0 0 var(--space-sm) 0;
+}
+
+.ai-section-good { color: #16a34a; }
+.ai-section-warn { color: #ca8a04; }
+.ai-section-error { color: #dc2626; }
+
+.ai-analyzer-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ai-analyzer-list li {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  line-height: 1.5;
+  padding-left: 16px;
+  position: relative;
+}
+
+.ai-analyzer-list li::before {
+  content: '•';
+  position: absolute;
+  left: 0;
+  color: var(--text-subtle);
+}
+
+.ai-analyzer-suggestion {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.ai-analyzer-suggestion-label {
+  font-weight: 600;
+  color: var(--text);
+  margin-right: 4px;
+}
+
+.ai-analyzer-cta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: var(--space-md) var(--space-lg);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--accent-primary);
+  background: var(--accent-primary-subtle);
+  border-top: 1px solid var(--border-muted);
+  transition: all var(--transition);
+}
+
+.ai-analyzer-cta:hover {
+  background: rgba(224, 122, 95, 0.15);
+}
+
+/* ===== AI Template Search ===== */
+.ai-template-search {
+  margin-top: var(--space-sm);
+}
+
+.ai-template-search-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: 6px 10px;
+  background: var(--accent-primary-subtle);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  transition: all var(--transition);
+}
+
+.ai-template-search-row:focus-within {
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 3px var(--accent-primary-subtle);
+}
+
+.ai-template-search-icon {
+  flex-shrink: 0;
+  color: var(--accent-primary);
+}
+
+.ai-template-search-input {
+  flex: 1;
+  background: none;
+  border: none;
+  outline: none;
+  font-size: var(--text-xs);
+  color: var(--text);
+}
+
+.ai-template-search-input::placeholder {
+  color: var(--accent-primary-muted);
+}
+
+.ai-template-search-error {
+  padding: 4px 8px;
+  margin-top: 4px;
+  font-size: 10px;
+  color: #dc2626;
+}
+
+.ai-template-search-results {
+  margin-top: var(--space-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ai-template-search-result {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: 6px 8px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-align: left;
+  transition: all var(--transition);
+}
+
+.ai-template-search-result:hover {
+  border-color: var(--accent-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.ai-template-search-thumb {
+  width: 48px;
+  height: 25px;
+  object-fit: cover;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.ai-template-search-info {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  flex: 1;
+}
+
+.ai-template-search-name {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ai-template-search-reason {
+  font-size: 10px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ai-template-search-score {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--accent-primary);
+  font-family: var(--font-mono);
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 768px) {
+  .ai-picker {
+    width: 280px;
+  }
+
+  .ai-picker-option {
+    padding: 12px;
+    min-height: 44px;
+  }
+
+  .ai-picker-btn {
+    min-height: 36px;
+    padding: 6px 12px;
+  }
+
+  .ai-generate-btn {
+    min-height: 28px;
+    padding: 4px 10px;
+  }
+
+  .ai-autofill-input {
+    font-size: 16px;
+    min-height: 44px;
+  }
+
+  .ai-autofill-trigger {
+    padding: 12px var(--space-md);
+    min-height: 44px;
+  }
+}
+
+@media (max-width: 768px) {
+  .ai-modal-overlay {
+    padding: 0;
+    align-items: flex-end;
+  }
+
+  .ai-modal {
+    max-width: 100%;
+    border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+    max-height: 90vh;
+    max-height: 90dvh;
+  }
+
+  .ai-provider-grid {
+    gap: var(--space-xs);
+  }
+
+  .ai-provider-btn {
+    min-width: 70px;
+    padding: 10px 8px;
+    font-size: 11px;
+    min-height: 44px;
+  }
+
+  .ai-key-input {
+    font-size: 16px;
+    min-height: 44px;
+  }
+
+  .ai-model-select {
+    font-size: 16px;
+    min-height: 44px;
+  }
+
+  .ai-btn {
+    min-height: 44px;
+  }
+
+  .ai-modal-close {
+    min-width: 44px;
+    min-height: 44px;
+  }
+}
+
+@media (max-width: 480px) {
+  .ai-modal-body {
+    padding: var(--space-md);
+  }
+
+  .ai-modal-header {
+    padding: var(--space-md);
+  }
+
+  .ai-provider-btn {
+    min-width: calc(33% - 6px);
+  }
+}

--- a/src/styles/api-docs.css
+++ b/src/styles/api-docs.css
@@ -137,6 +137,11 @@
   line-height: 1.6;
 }
 
+.endpoint-method-post {
+  background: rgba(59, 130, 246, 0.12);
+  color: #2563eb;
+}
+
 .endpoint-path {
   font-family: var(--font-mono);
   font-size: var(--text-sm);

--- a/src/styles/api-docs.css
+++ b/src/styles/api-docs.css
@@ -1,335 +1,439 @@
-/* ===== API Docs ===== */
+/* ===== API Docs — Mobile-first ===== */
+
 .api-docs {
-  display: grid;
-  grid-template-columns: 220px 1fr;
-  gap: var(--space-2xl);
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: var(--space-2xl) var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
 }
 
-/* Sidebar */
+/* ===== Hero (title + intro) ===== */
+.api-hero {
+  padding: var(--space-xl) var(--space-md) var(--space-lg);
+}
+
+.api-hero h1 {
+  font-size: var(--text-2xl);
+  margin-bottom: var(--space-sm);
+}
+
+.api-intro {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* ===== Sticky section nav (horizontal tabs on mobile) ===== */
 .api-sidebar {
   position: sticky;
-  top: calc(var(--nav-height) + var(--space-xl));
-  height: fit-content;
+  top: var(--nav-height);
+  z-index: 20;
+  background: var(--bg-frosted);
+  backdrop-filter: saturate(180%) blur(16px);
+  -webkit-backdrop-filter: saturate(180%) blur(16px);
+  border-bottom: 1px solid var(--border);
 }
 
 .api-sidebar-nav {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+  padding: 0 var(--space-md);
+  gap: 0;
+}
+
+.api-sidebar-nav::-webkit-scrollbar {
+  display: none;
 }
 
 .api-sidebar-link {
   display: flex;
   align-items: center;
-  gap: var(--space-sm);
-  padding: var(--space-sm) var(--space-md);
-  font-size: var(--text-sm);
+  gap: 6px;
+  padding: 0 var(--space-md);
+  height: 44px;
+  font-size: var(--text-xs);
+  font-weight: 500;
   color: var(--text-muted);
-  border-radius: var(--radius);
-  border-left: 2px solid transparent;
-  transition: all var(--transition);
+  white-space: nowrap;
+  border-bottom: 2px solid transparent;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+  -webkit-tap-highlight-color: transparent;
+  flex-shrink: 0;
 }
 
-.api-sidebar-link:hover {
+.api-sidebar-link:hover,
+.api-sidebar-link:active {
   color: var(--text);
-  background: var(--bg-surface);
 }
 
 .api-sidebar-link.active {
   color: var(--accent-primary);
-  background: var(--accent-primary-subtle);
-  border-left-color: var(--accent-primary);
-  font-weight: 500;
+  border-bottom-color: var(--accent-primary);
+  font-weight: 600;
 }
 
 .api-sidebar-icon {
+  width: 14px;
+  height: 14px;
+  opacity: 0.5;
   flex-shrink: 0;
-  width: 16px;
-  height: 16px;
-  opacity: 0.7;
 }
 
 .api-sidebar-link.active .api-sidebar-icon {
   opacity: 1;
 }
 
-/* Content */
+/* ===== Content ===== */
 .api-content {
+  padding: var(--space-lg) var(--space-md);
   min-width: 0;
+  max-width: 100%;
 }
 
-.api-content h1 {
-  font-size: var(--text-4xl);
-  margin-bottom: var(--space-md);
-}
-
-.api-intro {
-  font-size: var(--text-lg);
+.api-content h4 {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
   color: var(--text-muted);
-  margin-bottom: var(--space-3xl);
-  max-width: 600px;
+  margin: var(--space-lg) 0 var(--space-md);
 }
 
-/* Section anchors */
-.section-anchor {
-  color: var(--text-subtle);
-  text-decoration: none;
-  opacity: 0;
-  margin-left: var(--space-sm);
-  transition: opacity var(--transition);
-}
-
-.endpoint-card:hover .section-anchor {
-  opacity: 1;
-}
-
-.section-anchor:hover {
-  color: var(--accent-primary);
-}
-
-/* Endpoint Card */
+/* ===== Endpoint Card ===== */
 .endpoint-card {
   background: var(--bg-elevated);
   border: 1px solid var(--border);
-  border-radius: var(--radius-xl);
-  padding: var(--space-xl);
-  margin-bottom: var(--space-2xl);
-  box-shadow: var(--shadow-sm);
-  scroll-margin-top: calc(var(--nav-height) + var(--space-lg));
+  border-radius: var(--radius-lg);
+  padding: var(--space-lg) var(--space-md);
+  margin-bottom: var(--space-lg);
+  box-shadow: var(--shadow-xs);
+  scroll-margin-top: calc(var(--nav-height) + 56px);
 }
 
 .endpoint-header {
   display: flex;
   align-items: center;
-  gap: var(--space-md);
-  margin-bottom: var(--space-lg);
+  gap: var(--space-sm);
+  margin-bottom: var(--space-sm);
+  flex-wrap: wrap;
 }
 
 .endpoint-method {
   display: inline-flex;
-  padding: 4px 12px;
-  font-size: var(--text-xs);
+  align-items: center;
+  padding: 2px 10px;
+  font-size: 11px;
   font-weight: 700;
   text-transform: uppercase;
-  border-radius: var(--radius);
+  border-radius: var(--radius-sm);
   background: rgba(34, 197, 94, 0.12);
   color: #16a34a;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.03em;
+  flex-shrink: 0;
+  line-height: 1.6;
 }
 
 .endpoint-path {
   font-family: var(--font-mono);
-  font-size: var(--text-base);
-  font-weight: 500;
+  font-size: var(--text-sm);
+  font-weight: 600;
   color: var(--text);
+  word-break: break-all;
+  background: none;
+  padding: 0;
 }
 
 .endpoint-desc {
   font-size: var(--text-sm);
   color: var(--text-muted);
-  margin-bottom: var(--space-lg);
+  margin-bottom: var(--space-md);
+  line-height: 1.6;
 }
 
-/* Param Table */
-.param-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: var(--text-sm);
-  margin-bottom: var(--space-lg);
-}
-
-.param-table th {
-  text-align: left;
-  padding: var(--space-sm) var(--space-md);
-  border-bottom: 1px solid var(--border);
-  font-weight: 500;
-  color: var(--text-muted);
-  font-size: var(--text-xs);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.param-table td {
-  padding: var(--space-sm) var(--space-md);
-  border-bottom: 1px solid var(--border-muted);
-  vertical-align: top;
-}
-
-.param-table tr:nth-child(even) td {
+.endpoint-desc code {
+  font-size: 0.85em;
   background: var(--bg-surface);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: var(--font-mono);
 }
 
-.param-table tr:last-child td {
+/* ===== Param list (div-based) ===== */
+.param-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin-bottom: var(--space-md);
+}
+
+.param-item {
+  padding: var(--space-md) 0;
+  border-bottom: 1px solid var(--border-muted);
+}
+
+.param-item:last-child {
   border-bottom: none;
+  padding-bottom: 0;
+}
+
+.param-head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 4px;
 }
 
 .param-name {
   font-family: var(--font-mono);
-  font-size: var(--text-xs);
+  font-size: var(--text-sm);
+  font-weight: 600;
   color: var(--accent-primary);
-  white-space: nowrap;
+  background: none;
+  padding: 0;
 }
 
 .param-type {
   font-family: var(--font-mono);
-  font-size: var(--text-xs);
+  font-size: 11px;
   color: var(--text-subtle);
+  background: var(--bg-surface);
+  padding: 1px 8px;
+  border-radius: var(--radius-sm);
+  line-height: 1.5;
 }
 
 .param-required {
   font-size: 10px;
+  font-weight: 700;
   color: #ef4444;
-  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .param-desc {
-  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  line-height: 1.5;
+  margin: 0;
+  max-width: none;
 }
 
-/* Code Block — Terminal Chrome */
+.param-desc code {
+  font-size: 0.9em;
+  background: var(--bg-surface);
+  padding: 0 4px;
+  border-radius: 3px;
+  font-family: var(--font-mono);
+}
+
+/* ===== Code Block ===== */
 .code-block {
   background: #1a1a1a;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius);
   overflow: hidden;
   margin-bottom: var(--space-md);
-  box-shadow: var(--shadow-md);
 }
 
 .code-block-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 16px;
-  background: #252525;
+  padding: 8px 12px;
+  background: #222;
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  min-height: 36px;
 }
 
-.code-block-header span {
-  font-size: var(--text-xs);
-  color: #888;
+.code-block-lang {
+  font-size: 11px;
+  color: #777;
   font-family: var(--font-mono);
 }
 
-.code-block-dots {
-  display: flex;
-  gap: 6px;
-}
-
-.code-block-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-}
-
-.code-block-dot:nth-child(1) { background: #FF5F57; }
-.code-block-dot:nth-child(2) { background: #FEBC2E; }
-.code-block-dot:nth-child(3) { background: #28C840; }
-
 .code-block-copy {
-  padding: 3px 10px;
+  padding: 4px 12px;
   font-size: 11px;
   font-weight: 500;
-  color: #888;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #777;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all var(--transition);
+  transition: all var(--transition-fast);
+  min-height: 30px;
+  -webkit-tap-highlight-color: transparent;
 }
 
-.code-block-copy:hover {
+.code-block-copy:hover,
+.code-block-copy:active {
   color: #fff;
-  background: rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.12);
 }
 
 .code-block-body {
-  padding: var(--space-md) var(--space-lg);
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  color: #e0e0e0;
-  line-height: 1.7;
-  overflow-x: auto;
   margin: 0;
+  padding: var(--space-md);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: #d4d4d4;
+  line-height: 1.6;
+  white-space: pre;
+  word-break: normal;
+  overflow-wrap: normal;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
-/* Collapsible response */
-.code-block-collapsible {
-  overflow: hidden;
+.code-block-body code {
+  display: block;
+  background: none;
+  padding: 0;
+  font-size: inherit;
 }
 
-.code-block-toggle {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  width: 100%;
-  padding: var(--space-sm) var(--space-md);
-  font-size: var(--text-xs);
-  font-weight: 500;
-  color: #888;
-  background: #1e1e1e;
-  border: none;
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
-  cursor: pointer;
-  transition: color var(--transition);
-}
-
-.code-block-toggle:hover {
-  color: #ccc;
-}
-
-.code-block-toggle svg {
-  transition: transform var(--transition);
-}
-
-.code-block-toggle.expanded svg {
-  transform: rotate(180deg);
-}
-
-.code-tabs {
-  display: flex;
-  gap: var(--space-sm);
-  margin-bottom: var(--space-md);
-}
-
-.code-tab {
-  padding: 4px 10px;
-  font-size: var(--text-xs);
-  font-weight: 500;
-  background: transparent;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  color: var(--text-muted);
-  cursor: pointer;
-  transition: all var(--transition);
-}
-
-.code-tab:hover { border-color: var(--border-strong); color: var(--text); }
-.code-tab.active { background: var(--text); color: var(--bg); border-color: var(--text); }
-
-@media (max-width: 768px) {
-  .api-docs {
-    grid-template-columns: 1fr;
+/* ===== Small phone ===== */
+@media (max-width: 480px) {
+  .api-hero {
+    padding: var(--space-lg) var(--space-sm) var(--space-md);
   }
-  .api-sidebar {
-    position: static;
-    border-bottom: 1px solid var(--border);
-    padding-bottom: var(--space-lg);
+
+  .api-hero h1 {
+    font-size: var(--text-xl);
   }
+
   .api-sidebar-nav {
-    flex-direction: row;
-    overflow-x: auto;
-    gap: var(--space-sm);
+    padding: 0 var(--space-sm);
   }
+
+  .api-content {
+    padding: var(--space-md) var(--space-sm);
+  }
+
+  .endpoint-card {
+    padding: var(--space-md) var(--space-sm);
+    border-radius: var(--radius);
+    margin-bottom: var(--space-md);
+  }
+
+  .code-block-body {
+    padding: var(--space-sm) var(--space-md);
+    font-size: 11px;
+  }
+}
+
+/* ===== Desktop ===== */
+@media (min-width: 769px) {
+  .api-docs {
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    grid-template-rows: auto auto 1fr;
+    gap: 0 var(--space-2xl);
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: var(--space-2xl) var(--space-xl);
+  }
+
+  /* Hero spans full width on desktop */
+  .api-hero {
+    grid-column: 1 / -1;
+    padding: 0 0 var(--space-2xl);
+  }
+
+  .api-hero h1 {
+    font-size: var(--text-4xl);
+    margin-bottom: var(--space-md);
+  }
+
+  .api-intro {
+    font-size: var(--text-lg);
+    max-width: 600px;
+  }
+
+  /* Sidebar: vertical on desktop */
+  .api-sidebar {
+    position: sticky;
+    top: calc(var(--nav-height) + var(--space-xl));
+    height: fit-content;
+    background: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    border-bottom: none;
+    grid-row: 3;
+    grid-column: 1;
+  }
+
+  .api-sidebar-nav {
+    flex-direction: column;
+    overflow-x: visible;
+    padding: 0;
+    gap: 2px;
+  }
+
   .api-sidebar-link {
-    white-space: nowrap;
-    border-left: none;
-    border-bottom: 2px solid transparent;
+    height: auto;
+    padding: var(--space-sm) var(--space-md);
+    font-size: var(--text-sm);
+    border-bottom: none;
+    border-left: 2px solid transparent;
+    border-radius: var(--radius);
   }
+
+  .api-sidebar-link:hover {
+    background: var(--bg-surface);
+  }
+
   .api-sidebar-link.active {
-    border-left-color: transparent;
-    border-bottom-color: var(--accent-primary);
+    background: var(--accent-primary-subtle);
+    border-left-color: var(--accent-primary);
+    border-bottom-color: transparent;
+  }
+
+  .api-sidebar-icon {
+    width: 16px;
+    height: 16px;
+  }
+
+  .api-content {
+    padding: 0;
+    grid-row: 3;
+    grid-column: 2;
+  }
+
+  .endpoint-card {
+    padding: var(--space-xl);
+    margin-bottom: var(--space-2xl);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .endpoint-path {
+    font-size: var(--text-base);
+    word-break: normal;
+  }
+
+  .code-block {
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-md);
+  }
+
+  .code-block-header {
+    padding: 10px 16px;
+  }
+
+  .code-block-body {
+    padding: var(--space-md) var(--space-lg);
+    font-size: var(--text-xs);
+    line-height: 1.7;
+  }
+
+  /* Desktop param list can be a bit wider */
+  .param-desc {
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
   }
 }

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -2,7 +2,9 @@
 .editor-layout {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: 100%;
+  min-height: 100vh;
+  min-height: 100dvh;
   overflow: hidden;
   background: var(--bg);
 }
@@ -41,6 +43,12 @@
   font-size: var(--text-sm);
   color: var(--text-muted);
   margin-right: auto;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.editor-topbar-label {
+  flex-shrink: 0;
 }
 
 .editor-topbar-sep {
@@ -51,6 +59,9 @@
 .editor-topbar-name {
   font-weight: 500;
   color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* ===== Mobile Tabs ===== */
@@ -66,7 +77,7 @@
 
 .mobile-tab {
   flex: 1;
-  padding: var(--space-md);
+  padding: var(--space-md) var(--space-sm);
   font-size: var(--text-sm);
   font-weight: 500;
   color: var(--text-muted);
@@ -75,7 +86,8 @@
   border-bottom: 2px solid transparent;
   cursor: pointer;
   transition: color var(--transition), border-color var(--transition);
-  min-height: 44px;
+  min-height: 48px;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .mobile-tab.active {
@@ -193,6 +205,8 @@
   transition: all var(--transition);
   text-align: left;
   padding: 0;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
 }
 
 .template-thumb:hover { border-color: var(--border-strong); transform: translateY(-2px); box-shadow: var(--shadow-md); }
@@ -203,6 +217,7 @@
   aspect-ratio: 1200 / 630;
   overflow: hidden;
   background: var(--bg-subtle);
+  background-image: linear-gradient(135deg, var(--bg-subtle) 0%, var(--bg-surface) 100%);
 }
 
 .template-thumb-preview img {
@@ -325,6 +340,7 @@
   justify-content: space-between;
   padding: var(--space-md) var(--space-lg);
   border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
 }
 
 .customize-title {
@@ -338,12 +354,24 @@
   font-size: var(--text-xs);
   color: var(--text-subtle);
   background: none;
-  border: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: color var(--transition);
+  transition: all var(--transition);
+  padding: var(--space-sm) var(--space-md);
+  min-height: 36px;
+  -webkit-tap-highlight-color: transparent;
 }
 
-.customize-reset:hover { color: var(--accent-primary); }
+.customize-reset:hover {
+  color: var(--accent-primary);
+  border-color: var(--accent-primary);
+  background: var(--accent-primary-subtle);
+}
+
+.customize-reset:active {
+  transform: scale(0.97);
+}
 
 .customize-fields {
   flex: 1;
@@ -353,6 +381,10 @@
 
 .customize-group {
   margin-bottom: var(--space-lg);
+}
+
+.customize-group:last-child {
+  margin-bottom: 0;
 }
 
 .customize-group-title {
@@ -411,8 +443,10 @@
   appearance: none;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' stroke='%23999' stroke-width='2'%3E%3Cpath d='M2 4l4 4 4-4'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
-  background-position: right 10px center;
-  padding-right: 28px;
+  background-position: right 12px center;
+  padding-right: 32px;
+  min-height: 40px;
+  cursor: pointer;
 }
 
 /* Color Picker */
@@ -430,6 +464,7 @@
   cursor: pointer;
   padding: 2px;
   flex-shrink: 0;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .editor-color-text {
@@ -443,17 +478,21 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  min-height: 44px;
 }
 
 .editor-toggle {
-  width: 40px;
-  height: 22px;
+  width: 44px;
+  height: 26px;
   background: var(--border-strong);
   border: none;
-  border-radius: 11px;
+  border-radius: 13px;
   cursor: pointer;
   position: relative;
   transition: background var(--transition);
+  flex-shrink: 0;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
 }
 
 .editor-toggle.active {
@@ -462,13 +501,14 @@
 
 .editor-toggle-thumb {
   position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 18px;
-  height: 18px;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
   background: white;
   border-radius: 50%;
   transition: transform var(--transition);
+  box-shadow: var(--shadow-xs);
 }
 
 .editor-toggle.active .editor-toggle-thumb {
@@ -491,18 +531,19 @@
 
 .editor-slider {
   width: 100%;
-  height: 4px;
+  height: 6px;
   -webkit-appearance: none;
   appearance: none;
   background: var(--border);
-  border-radius: 2px;
+  border-radius: 3px;
   outline: none;
+  touch-action: manipulation;
 }
 
 .editor-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
-  width: 16px;
-  height: 16px;
+  width: 18px;
+  height: 18px;
   background: var(--accent-primary);
   border-radius: 50%;
   cursor: pointer;
@@ -514,7 +555,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 6px 12px;
+  padding: 8px 14px;
   font-size: var(--text-xs);
   font-weight: 500;
   color: var(--text-muted);
@@ -524,11 +565,17 @@
   cursor: pointer;
   margin-top: 6px;
   transition: all var(--transition);
+  -webkit-tap-highlight-color: transparent;
+  min-height: 40px;
 }
 
 .editor-upload-btn:hover {
   border-color: var(--border-strong);
   color: var(--text);
+}
+
+.editor-upload-btn:active {
+  transform: scale(0.97);
 }
 
 /* ===== Export Bar ===== */
@@ -547,7 +594,7 @@
 .export-btn {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   padding: 6px 14px;
   font-size: var(--text-xs);
   font-weight: 500;
@@ -556,6 +603,12 @@
   border: 1px solid transparent;
   transition: all var(--transition);
   white-space: nowrap;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+.export-btn:active {
+  transform: scale(0.97);
 }
 
 .export-btn-primary {
@@ -566,15 +619,17 @@
 }
 
 .export-btn-primary:hover { box-shadow: var(--shadow-md), var(--shadow-glow); }
-.export-btn-primary:disabled { opacity: 0.6; cursor: not-allowed; }
+.export-btn-primary:active { box-shadow: var(--shadow-xs); }
+.export-btn-primary:disabled { opacity: 0.6; cursor: not-allowed; transform: none; }
 
 .export-btn-ghost {
-  background: transparent;
+  background: var(--bg-elevated);
   color: var(--text-muted);
   border-color: var(--border);
 }
 
 .export-btn-ghost:hover { background: var(--bg-surface); color: var(--text); border-color: var(--border-strong); }
+.export-btn-ghost:active { background: var(--bg-surface); }
 
 /* ===== Platform Preview Strip ===== */
 .platform-strip {
@@ -602,6 +657,7 @@
   overflow-x: auto;
   padding-bottom: var(--space-sm);
   scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
 }
 
 .platform-strip-scroll::-webkit-scrollbar { display: none; }
@@ -611,11 +667,17 @@
   cursor: pointer;
   border-radius: var(--radius);
   transition: transform var(--transition), box-shadow var(--transition);
+  min-width: 120px;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .platform-mini:hover {
   transform: translateY(-2px) scale(1.02);
   box-shadow: var(--shadow-md);
+}
+
+.platform-mini:active {
+  transform: scale(0.98);
 }
 
 .platform-mini-header {
@@ -701,8 +763,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--space-xl);
+  padding: var(--space-md);
   animation: fadeIn 0.15s ease-out;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .platform-expanded-card {
@@ -756,24 +819,69 @@
 
 .platform-expanded-body {
   padding: var(--space-lg);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.platform-expanded-close {
+  min-width: 44px;
+  min-height: 44px;
 }
 
 /* ===== Export Mobile ===== */
 .editor-export-mobile {
-  padding: var(--space-xl);
+  padding: var(--space-lg) var(--space-md);
+  padding-bottom: max(var(--space-xl), env(safe-area-inset-bottom));
   display: flex;
   flex-direction: column;
-  gap: var(--space-md);
+  gap: var(--space-lg);
+  width: 100%;
+}
+
+.editor-export-preview {
+  display: none;
 }
 
 .editor-export-mobile .export-bar {
   flex-direction: column;
 }
 
+.editor-export-mobile .export-buttons {
+  flex-direction: column;
+  width: 100%;
+  gap: var(--space-sm);
+}
+
 .editor-export-mobile .export-btn {
   width: 100%;
-  padding: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
   font-size: var(--text-sm);
+  min-height: 52px;
+  justify-content: center;
+  border-radius: var(--radius-lg);
+}
+
+.editor-export-mobile .export-btn-primary {
+  font-size: var(--text-base);
+  font-weight: 600;
+  gap: var(--space-sm);
+  min-height: 56px;
+}
+
+.editor-export-mobile .export-btn-primary svg {
+  width: 18px;
+  height: 18px;
+}
+
+.editor-export-mobile .export-btn-ghost {
+  background: var(--bg-surface);
+  border-color: var(--border);
+}
+
+.editor-export-mobile .platform-strip {
+  margin-top: var(--space-sm);
+  border-top: 1px solid var(--border-muted);
+  padding-top: var(--space-lg);
 }
 
 /* ===== Responsive ===== */
@@ -786,20 +894,374 @@
   .editor-topbar .export-bar { display: none; }
   .editor-mobile-tabs-wrapper { display: block; }
 
-  .editor-panels { flex-direction: column; }
-  .editor-left,
-  .editor-right {
+  .editor-topbar {
+    gap: var(--space-sm);
+  }
+
+  .editor-topbar-label {
+    display: none;
+  }
+
+  .editor-logo-img {
+    height: 20px;
+  }
+
+  .editor-panels {
+    flex-direction: column;
+    overflow-y: auto;
+    overflow-x: hidden;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .editor-left {
     width: 100%;
     border-left: none;
     border-right: none;
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
   }
 
-  .editor-left { height: 100%; }
-  .editor-center { height: 100%; padding: var(--space-md); }
-  .editor-right { height: 100%; }
+  .editor-center {
+    width: 100%;
+    height: auto;
+    min-height: auto;
+    flex: none;
+    padding: var(--space-md);
+    overflow: visible;
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    background: var(--bg);
+    border-bottom: 1px solid var(--border-muted);
+  }
+
+  .editor-right {
+    width: 100%;
+    min-height: 0;
+    border-left: none;
+    border-right: none;
+    flex: 1 1 auto;
+    flex-direction: column;
+    overflow: visible;
+  }
+
+  .editor-center .canvas-wrapper {
+    min-height: 200px;
+    max-height: 35vh;
+    flex-shrink: 0;
+    border-radius: var(--radius);
+  }
+
+  .editor-center .platform-strip {
+    display: none;
+  }
+
+  .editor-right .customize-panel {
+    height: auto;
+    width: 100%;
+    padding-bottom: max(var(--space-lg), env(safe-area-inset-bottom));
+  }
+
+  .editor-right .customize-header {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background: var(--bg-elevated);
+    padding: var(--space-sm) var(--space-md);
+    backdrop-filter: saturate(180%) blur(12px);
+    -webkit-backdrop-filter: saturate(180%) blur(12px);
+  }
+
+  .editor-right .customize-fields {
+    padding: var(--space-md);
+    overflow: visible;
+  }
+
+  .editor-right .customize-group-title {
+    position: sticky;
+    top: 0;
+    background: var(--bg);
+    padding-top: var(--space-sm);
+    z-index: 1;
+  }
+
+  .editor-export-preview {
+    display: block;
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    box-shadow: var(--shadow-md);
+  }
+
+  .editor-export-preview .canvas-wrapper {
+    min-height: 120px;
+    max-height: 28vh;
+    border-radius: var(--radius-lg);
+  }
+
+  .editor-field-textarea {
+    min-height: 80px;
+  }
+
+  .editor-select {
+    font-size: 16px;
+    min-height: 44px;
+  }
+
+  .editor-upload-btn {
+    width: 100%;
+    min-height: 44px;
+    justify-content: center;
+  }
+
+  .editor-toggle {
+    width: 48px;
+    height: 28px;
+    border-radius: 14px;
+  }
+
+  .editor-toggle-thumb {
+    width: 22px;
+    height: 22px;
+  }
+
+  .editor-toggle.active .editor-toggle-thumb {
+    transform: translateX(20px);
+  }
 
   .mobile-hide { display: none !important; }
   .mobile-show { display: flex !important; }
 
-  .template-grid { grid-template-columns: repeat(2, 1fr); }
+  .template-grid {
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+    flex: 1;
+    align-content: start;
+  }
+
+  .template-thumb {
+    min-height: 0;
+    border-radius: var(--radius-sm);
+  }
+
+  .template-thumb:active {
+    transform: scale(0.97);
+    box-shadow: none;
+  }
+
+  .template-thumb-preview {
+    border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  }
+
+  .platform-strip-header {
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+  }
+
+  .platform-strip-scroll {
+    margin-left: calc(-1 * var(--space-md));
+    margin-right: calc(-1 * var(--space-md));
+    padding-left: var(--space-md);
+    padding-right: var(--space-md);
+    gap: var(--space-sm);
+  }
+
+  .platform-expanded-overlay {
+    padding: var(--space-sm);
+    align-items: flex-end;
+  }
+
+  .platform-expanded-card {
+    max-height: 85vh;
+    max-height: 85dvh;
+    overflow-y: auto;
+    border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+  }
+
+  .platform-expanded-header {
+    padding: var(--space-md);
+    position: sticky;
+    top: 0;
+    background: var(--bg-elevated);
+    z-index: 1;
+  }
+
+  .platform-expanded-body {
+    padding: var(--space-md);
+  }
+
+  .viewport-switcher-compact .viewport-btn {
+    padding: 6px 10px;
+    min-height: 36px;
+  }
+
+  .template-panel-header {
+    padding: var(--space-sm) var(--space-md);
+  }
+
+  .template-search {
+    font-size: 16px;
+    min-height: 44px;
+    padding: var(--space-sm) var(--space-md);
+  }
+
+  .template-categories {
+    padding: var(--space-xs) var(--space-md);
+  }
+
+  .editor-color-swatch {
+    width: 44px;
+    height: 44px;
+  }
+
+  .editor-slider::-webkit-slider-thumb {
+    width: 24px;
+    height: 24px;
+  }
+}
+
+/* Small phones: larger touch targets, tighter spacing */
+@media (max-width: 480px) {
+  .editor-topbar {
+    padding: 0 var(--space-sm);
+    min-height: 44px;
+    height: 44px;
+    gap: var(--space-xs);
+  }
+
+  .editor-topbar-name {
+    font-size: var(--text-xs);
+  }
+
+  .editor-logo-img {
+    height: 18px;
+  }
+
+  .mobile-tab {
+    font-size: var(--text-xs);
+    min-height: 44px;
+    padding: var(--space-sm) var(--space-xs);
+  }
+
+  .editor-center {
+    padding: var(--space-sm);
+  }
+
+  .editor-center .canvas-wrapper {
+    min-height: 180px;
+    max-height: 36vh;
+  }
+
+  .customize-fields {
+    padding: var(--space-sm) var(--space-md);
+  }
+
+  .editor-field {
+    margin-bottom: var(--space-lg);
+  }
+
+  .editor-field-label {
+    font-size: var(--text-sm);
+    margin-bottom: 6px;
+  }
+
+  .editor-field-input {
+    font-size: 16px;
+    min-height: 48px;
+    padding: 12px 14px;
+    border-radius: var(--radius);
+  }
+
+  .editor-field-textarea {
+    min-height: 90px;
+  }
+
+  .editor-color-swatch {
+    width: 48px;
+    height: 48px;
+    border-radius: var(--radius);
+  }
+
+  .editor-color-text {
+    font-size: var(--text-sm);
+    min-height: 48px;
+  }
+
+  .editor-slider {
+    height: 8px;
+    border-radius: 4px;
+  }
+
+  .editor-slider::-webkit-slider-thumb {
+    width: 28px;
+    height: 28px;
+  }
+
+  .editor-select {
+    min-height: 48px;
+    border-radius: var(--radius);
+  }
+
+  .editor-upload-btn {
+    min-height: 48px;
+    font-size: var(--text-sm);
+    border-radius: var(--radius);
+  }
+
+  .editor-export-mobile {
+    padding: var(--space-md);
+  }
+
+  .editor-export-mobile .export-btn {
+    min-height: 52px;
+    border-radius: var(--radius);
+  }
+
+  .editor-export-mobile .export-btn-primary {
+    min-height: 56px;
+  }
+
+  .editor-export-preview .canvas-wrapper {
+    min-height: 100px;
+    max-height: 25vh;
+  }
+
+  .template-cat-pill {
+    min-height: 40px;
+    padding: 8px 14px;
+    font-size: 10px;
+  }
+
+  .template-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .template-thumb-name {
+    font-size: 10px;
+    padding: 5px 6px;
+  }
+}
+
+/* Very narrow phones */
+@media (max-width: 380px) {
+  .template-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .customize-group-title {
+    font-size: 10px;
+  }
+
+  .editor-export-mobile .export-btn-primary {
+    font-size: var(--text-sm);
+    min-height: 52px;
+  }
+
+  .platform-mini {
+    min-width: 100px;
+  }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -628,7 +628,7 @@ p {
 }
 
 @media (max-width: 768px) {
-  :root { --space-5xl: 4rem; --space-4xl: 3rem; --space-3xl: 2.5rem; }
+  :root { --space-5xl: 4rem; --space-4xl: 3rem; --space-3xl: 2.5rem; --nav-height: 56px; }
   h1 { font-size: var(--text-3xl); }
   h2 { font-size: var(--text-2xl); }
   .section { padding: var(--space-4xl) 0; }
@@ -640,6 +640,7 @@ p {
 }
 
 @media (max-width: 480px) {
+  :root { --nav-height: 52px; }
   .container { padding: 0 var(--space-md); }
 }
 

--- a/src/styles/preview.css
+++ b/src/styles/preview.css
@@ -479,9 +479,91 @@
 .viewport-btn-active .viewport-btn-size { color: var(--accent-primary); }
 
 @media (max-width: 768px) {
-  .preview-url-row { flex-direction: column; }
-  .platform-grid { grid-template-columns: 1fr; }
-  .meta-report-header { flex-direction: column; text-align: center; }
-  .platform-section-header { flex-direction: column; align-items: flex-start; }
-  .viewport-btn-label { display: none; }
+  .preview-app {
+    padding: var(--space-xl) var(--space-md);
+  }
+
+  .preview-header h1 {
+    font-size: var(--text-2xl);
+  }
+
+  .preview-header p {
+    font-size: var(--text-base);
+  }
+
+  .preview-url-row {
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+
+  .preview-url-field {
+    font-size: 16px; /* Prevents iOS zoom on focus */
+    min-height: 48px;
+    padding: var(--space-md) var(--space-lg);
+  }
+
+  .preview-url-btn {
+    width: 100%;
+    min-height: 48px;
+    padding: var(--space-lg);
+    font-size: var(--text-base);
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .platform-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .meta-report {
+    padding: var(--space-lg);
+  }
+
+  .meta-report-header {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .meta-score {
+    width: 72px;
+    height: 72px;
+  }
+
+  .platform-section-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .viewport-btn-label {
+    display: none;
+  }
+
+  .platform-card-mockup {
+    padding: var(--space-md);
+    min-height: 100px;
+  }
+
+  .fix-it-actions {
+    flex-direction: column;
+  }
+
+  .fix-it-actions a,
+  .fix-it-actions button {
+    width: 100%;
+    min-height: 48px;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .preview-app {
+    padding: var(--space-lg) var(--space-sm);
+  }
+
+  .preview-header {
+    margin-bottom: var(--space-xl);
+  }
+
+  .preview-header h1 {
+    font-size: var(--text-xl);
+  }
 }

--- a/tests/ai/autofill.test.ts
+++ b/tests/ai/autofill.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { parseAutofillResponse } from '@/lib/ai/autofill';
+
+describe('parseAutofillResponse', () => {
+  it('should parse clean JSON response', () => {
+    const result = parseAutofillResponse(JSON.stringify({
+      templateId: 'blog-minimal-dark',
+      fields: { title: 'Hello World', author: 'John' },
+      colors: { bgColor: '#1a1a2e' },
+    }));
+    expect(result).not.toBeNull();
+    expect(result!.templateId).toBe('blog-minimal-dark');
+    expect(result!.fields.title).toBe('Hello World');
+    expect(result!.colors?.bgColor).toBe('#1a1a2e');
+  });
+
+  it('should parse JSON from markdown code block', () => {
+    const result = parseAutofillResponse('```json\n{"templateId":"blog-code-dark","fields":{"title":"Test"}}\n```');
+    expect(result).not.toBeNull();
+    expect(result!.templateId).toBe('blog-code-dark');
+  });
+
+  it('should extract JSON from surrounding text', () => {
+    const result = parseAutofillResponse('Here is the result:\n{"templateId":"product-centered-hero","fields":{"title":"Launch"}}\nDone!');
+    expect(result).not.toBeNull();
+    expect(result!.templateId).toBe('product-centered-hero');
+  });
+
+  it('should return null for invalid JSON', () => {
+    expect(parseAutofillResponse('not json at all')).toBeNull();
+  });
+
+  it('should return null for empty string', () => {
+    expect(parseAutofillResponse('')).toBeNull();
+  });
+
+  it('should return null for JSON without templateId', () => {
+    expect(parseAutofillResponse('{"fields":{"title":"test"}}')).toBeNull();
+  });
+
+  it('should return null for JSON without fields', () => {
+    expect(parseAutofillResponse('{"templateId":"test"}')).toBeNull();
+  });
+
+  it('should handle response without colors', () => {
+    const result = parseAutofillResponse('{"templateId":"blog-minimal-dark","fields":{"title":"Test"}}');
+    expect(result).not.toBeNull();
+    expect(result!.colors).toBeUndefined();
+  });
+});

--- a/tests/ai/generate.test.ts
+++ b/tests/ai/generate.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { parseAIResponse } from '@/lib/ai/generate';
+
+describe('parseAIResponse', () => {
+  it('should parse clean JSON array', () => {
+    const result = parseAIResponse('["Title One", "Title Two", "Title Three"]');
+    expect(result).toEqual(['Title One', 'Title Two', 'Title Three']);
+  });
+
+  it('should parse JSON with whitespace', () => {
+    const result = parseAIResponse('  \n["Title One", "Title Two"]  \n');
+    expect(result).toEqual(['Title One', 'Title Two']);
+  });
+
+  it('should parse markdown-wrapped JSON', () => {
+    const result = parseAIResponse('```json\n["Title One", "Title Two"]\n```');
+    expect(result).toEqual(['Title One', 'Title Two']);
+  });
+
+  it('should parse markdown without json tag', () => {
+    const result = parseAIResponse('```\n["Title One", "Title Two"]\n```');
+    expect(result).toEqual(['Title One', 'Title Two']);
+  });
+
+  it('should extract JSON array from surrounding text', () => {
+    const result = parseAIResponse('Here are some titles:\n["Title One", "Title Two"]\nHope these help!');
+    expect(result).toEqual(['Title One', 'Title Two']);
+  });
+
+  it('should filter out non-string values', () => {
+    const result = parseAIResponse('[1, "Title One", null, "Title Two", true]');
+    expect(result).toEqual(['Title One', 'Title Two']);
+  });
+
+  it('should fallback to newline splitting for plain text', () => {
+    const result = parseAIResponse('Title One\nTitle Two\nTitle Three');
+    expect(result).toEqual(['Title One', 'Title Two', 'Title Three']);
+  });
+
+  it('should handle numbered list fallback', () => {
+    const result = parseAIResponse('1. Title One\n2. Title Two\n3. Title Three');
+    expect(result).toEqual(['Title One', 'Title Two', 'Title Three']);
+  });
+
+  it('should handle bullet list fallback', () => {
+    const result = parseAIResponse('- Title One\n- Title Two\n- Title Three');
+    expect(result).toEqual(['Title One', 'Title Two', 'Title Three']);
+  });
+
+  it('should strip surrounding quotes in fallback', () => {
+    const result = parseAIResponse('"Title One"\n"Title Two"');
+    expect(result).toEqual(['Title One', 'Title Two']);
+  });
+
+  it('should filter empty lines in fallback', () => {
+    const result = parseAIResponse('Title One\n\n\nTitle Two');
+    expect(result).toEqual(['Title One', 'Title Two']);
+  });
+
+  it('should handle completely empty response', () => {
+    const result = parseAIResponse('');
+    expect(result).toEqual([]);
+  });
+});

--- a/tests/ai/prompts.test.ts
+++ b/tests/ai/prompts.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { buildTitlePrompt, buildSubtitlePrompt, buildGenericFieldPrompt, getPromptForField } from '@/lib/ai/prompts';
+
+describe('buildTitlePrompt', () => {
+  it('should include category in prompt', () => {
+    const { prompt } = buildTitlePrompt({ fieldName: 'title', category: 'blog' });
+    expect(prompt).toContain('blog');
+  });
+
+  it('should include character limit', () => {
+    const { prompt } = buildTitlePrompt({ fieldName: 'title' });
+    expect(prompt).toContain('60 characters');
+  });
+
+  it('should request JSON array format', () => {
+    const { prompt } = buildTitlePrompt({ fieldName: 'title' });
+    expect(prompt).toContain('JSON array');
+  });
+
+  it('should include existing fields as context', () => {
+    const { prompt } = buildTitlePrompt({
+      fieldName: 'title',
+      currentValues: { author: 'John Doe', description: 'A blog post' },
+    });
+    expect(prompt).toContain('author: "John Doe"');
+    expect(prompt).toContain('description: "A blog post"');
+  });
+
+  it('should use count parameter', () => {
+    const { prompt } = buildTitlePrompt({ fieldName: 'title', count: 5 });
+    expect(prompt).toContain('5');
+  });
+});
+
+describe('buildSubtitlePrompt', () => {
+  it('should reference the title when available', () => {
+    const { prompt } = buildSubtitlePrompt({
+      fieldName: 'subtitle',
+      currentValues: { title: 'My Great Title' },
+    });
+    expect(prompt).toContain('My Great Title');
+  });
+
+  it('should handle missing title', () => {
+    const { prompt } = buildSubtitlePrompt({ fieldName: 'subtitle' });
+    expect(prompt).toContain('standalone subtitle');
+  });
+
+  it('should include 80 character limit', () => {
+    const { prompt } = buildSubtitlePrompt({ fieldName: 'subtitle' });
+    expect(prompt).toContain('80 characters');
+  });
+});
+
+describe('buildGenericFieldPrompt', () => {
+  it('should include field name', () => {
+    const { prompt, systemPrompt } = buildGenericFieldPrompt({ fieldName: 'Author Name' });
+    expect(prompt).toContain('Author Name');
+    expect(systemPrompt).toContain('Author Name');
+  });
+});
+
+describe('getPromptForField', () => {
+  it('should use title prompt for title field', () => {
+    const { prompt } = getPromptForField({ fieldName: 'Title' });
+    expect(prompt).toContain('60 characters');
+  });
+
+  it('should use subtitle prompt for description field', () => {
+    const { prompt } = getPromptForField({ fieldName: 'Description' });
+    expect(prompt).toContain('80 characters');
+  });
+
+  it('should use subtitle prompt for subtitle field', () => {
+    const { prompt } = getPromptForField({ fieldName: 'Subtitle' });
+    expect(prompt).toContain('80 characters');
+  });
+
+  it('should use generic prompt for other fields', () => {
+    const { prompt, systemPrompt } = getPromptForField({ fieldName: 'Author' });
+    expect(prompt).toContain('"Author"');
+    expect(systemPrompt).toContain('"Author"');
+    // Should not contain title-specific or subtitle-specific wording
+    expect(prompt).not.toContain('click-worthy');
+    expect(prompt).not.toContain('Complement the title');
+  });
+});

--- a/tests/ai/providers.test.ts
+++ b/tests/ai/providers.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect } from 'vitest';
+import { getProvider, getAllProviders, getModelsForProvider, getDefaultModel, isValidProvider } from '@/lib/ai/providers';
+import { AI_PROVIDERS } from '@/lib/ai/types';
+import type { AIProvider } from '@/lib/ai/types';
+
+describe('AI Provider Registry', () => {
+  it('should have all 5 providers registered', () => {
+    const providers = getAllProviders();
+    expect(providers).toHaveLength(5);
+    expect(providers.map((p) => p.id).sort()).toEqual(
+      ['anthropic', 'google', 'groq', 'openai', 'openrouter']
+    );
+  });
+
+  it('should return correct config for each provider', () => {
+    for (const id of AI_PROVIDERS) {
+      const provider = getProvider(id);
+      expect(provider).toBeDefined();
+      expect(provider!.id).toBe(id);
+      expect(provider!.name).toBeTruthy();
+      expect(provider!.baseUrl).toMatch(/^https:\/\//);
+      expect(provider!.apiKeyUrl).toMatch(/^https:\/\//);
+    }
+  });
+
+  it('should return undefined for unknown provider', () => {
+    expect(getProvider('nonexistent' as AIProvider)).toBeUndefined();
+  });
+
+  it('should have at least 2 models per provider', () => {
+    for (const id of AI_PROVIDERS) {
+      const models = getModelsForProvider(id);
+      expect(models.length).toBeGreaterThanOrEqual(2);
+      for (const model of models) {
+        expect(model.id).toBeTruthy();
+        expect(model.name).toBeTruthy();
+        expect(model.provider).toBe(id);
+        expect(model.maxTokens).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('should return empty array for unknown provider models', () => {
+    expect(getModelsForProvider('nonexistent' as AIProvider)).toEqual([]);
+  });
+
+  it('should return a default model for each provider', () => {
+    for (const id of AI_PROVIDERS) {
+      const defaultModel = getDefaultModel(id);
+      expect(defaultModel).toBeTruthy();
+      // Default model should be in the provider's model list
+      const models = getModelsForProvider(id);
+      expect(models.some((m) => m.id === defaultModel)).toBe(true);
+    }
+  });
+
+  it('should return undefined for unknown provider default model', () => {
+    expect(getDefaultModel('nonexistent' as AIProvider)).toBeUndefined();
+  });
+
+  it('should validate provider IDs correctly', () => {
+    expect(isValidProvider('openai')).toBe(true);
+    expect(isValidProvider('anthropic')).toBe(true);
+    expect(isValidProvider('google')).toBe(true);
+    expect(isValidProvider('groq')).toBe(true);
+    expect(isValidProvider('openrouter')).toBe(true);
+    expect(isValidProvider('nonexistent')).toBe(false);
+    expect(isValidProvider('')).toBe(false);
+  });
+});
+
+describe('AI Provider Header Builders', () => {
+  it('should build OpenAI headers with Bearer token', () => {
+    const provider = getProvider('openai')!;
+    const headers = provider.headerBuilder('sk-test-key');
+    expect(headers['Authorization']).toBe('Bearer sk-test-key');
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+
+  it('should build Anthropic headers with x-api-key', () => {
+    const provider = getProvider('anthropic')!;
+    const headers = provider.headerBuilder('sk-ant-test-key');
+    expect(headers['x-api-key']).toBe('sk-ant-test-key');
+    expect(headers['anthropic-version']).toBe('2023-06-01');
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+
+  it('should build Google headers (key via query param, not header)', () => {
+    const provider = getProvider('google')!;
+    const headers = provider.headerBuilder('google-key');
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(headers['Authorization']).toBeUndefined();
+  });
+
+  it('should build Groq headers with Bearer token', () => {
+    const provider = getProvider('groq')!;
+    const headers = provider.headerBuilder('gsk-test-key');
+    expect(headers['Authorization']).toBe('Bearer gsk-test-key');
+  });
+
+  it('should build OpenRouter headers with referer', () => {
+    const provider = getProvider('openrouter')!;
+    const headers = provider.headerBuilder('sk-or-test-key');
+    expect(headers['Authorization']).toBe('Bearer sk-or-test-key');
+    expect(headers['HTTP-Referer']).toBeTruthy();
+    expect(headers['X-Title']).toBe('OGCOPS');
+  });
+});
+
+describe('AI Provider Body Formatters', () => {
+  const baseParams = {
+    model: 'test-model',
+    prompt: 'Generate a title',
+    systemPrompt: 'You are a helper',
+    maxTokens: 200,
+    temperature: 0.7,
+  };
+
+  it('should format OpenAI-style body (OpenAI)', () => {
+    const provider = getProvider('openai')!;
+    const { url, body } = provider.bodyFormatter(baseParams);
+    expect(url).toContain('/chat/completions');
+    const b = body as any;
+    expect(b.model).toBe('test-model');
+    expect(b.messages).toHaveLength(2);
+    expect(b.messages[0]).toEqual({ role: 'system', content: 'You are a helper' });
+    expect(b.messages[1]).toEqual({ role: 'user', content: 'Generate a title' });
+    expect(b.max_tokens).toBe(200);
+    expect(b.temperature).toBe(0.7);
+  });
+
+  it('should format OpenAI-style body without system prompt', () => {
+    const provider = getProvider('openai')!;
+    const { body } = provider.bodyFormatter({ ...baseParams, systemPrompt: undefined });
+    const b = body as any;
+    expect(b.messages).toHaveLength(1);
+    expect(b.messages[0].role).toBe('user');
+  });
+
+  it('should format Anthropic-style body', () => {
+    const provider = getProvider('anthropic')!;
+    const { url, body } = provider.bodyFormatter(baseParams);
+    expect(url).toContain('/v1/messages');
+    const b = body as any;
+    expect(b.model).toBe('test-model');
+    expect(b.system).toBe('You are a helper');
+    expect(b.messages).toHaveLength(1);
+    expect(b.messages[0]).toEqual({ role: 'user', content: 'Generate a title' });
+    expect(b.max_tokens).toBe(200);
+    expect(b.temperature).toBe(0.7);
+  });
+
+  it('should format Anthropic body without system prompt', () => {
+    const provider = getProvider('anthropic')!;
+    const { body } = provider.bodyFormatter({ ...baseParams, systemPrompt: undefined });
+    const b = body as any;
+    expect(b.system).toBeUndefined();
+  });
+
+  it('should format Google Gemini body', () => {
+    const provider = getProvider('google')!;
+    const { url, body } = provider.bodyFormatter(baseParams);
+    expect(url).toContain('generateContent');
+    expect(url).toContain('test-model');
+    const b = body as any;
+    expect(b.contents[0].parts[0].text).toContain('Generate a title');
+    expect(b.contents[0].parts[0].text).toContain('You are a helper');
+    expect(b.generationConfig.maxOutputTokens).toBe(200);
+    expect(b.generationConfig.temperature).toBe(0.7);
+  });
+
+  it('should format Groq body (OpenAI-compatible)', () => {
+    const provider = getProvider('groq')!;
+    const { url, body } = provider.bodyFormatter(baseParams);
+    expect(url).toContain('groq.com');
+    expect(url).toContain('/chat/completions');
+    const b = body as any;
+    expect(b.messages).toHaveLength(2);
+  });
+
+  it('should format OpenRouter body (OpenAI-compatible)', () => {
+    const provider = getProvider('openrouter')!;
+    const { url, body } = provider.bodyFormatter(baseParams);
+    expect(url).toContain('openrouter.ai');
+    expect(url).toContain('/chat/completions');
+    const b = body as any;
+    expect(b.messages).toHaveLength(2);
+  });
+
+  it('should use defaults when maxTokens and temperature are not provided', () => {
+    const provider = getProvider('openai')!;
+    const { body } = provider.bodyFormatter({ model: 'gpt-4o', prompt: 'hi' });
+    const b = body as any;
+    expect(b.max_tokens).toBe(300);
+    expect(b.temperature).toBe(0.8);
+  });
+});
+
+describe('AI Provider Response Parsers', () => {
+  it('should parse OpenAI response', () => {
+    const provider = getProvider('openai')!;
+    const result = provider.responseParser({
+      choices: [{ message: { content: 'Hello world' } }],
+      model: 'gpt-4o-mini',
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+    });
+    expect(result.content).toBe('Hello world');
+    expect(result.model).toBe('gpt-4o-mini');
+    expect(result.usage).toEqual({ inputTokens: 10, outputTokens: 5 });
+  });
+
+  it('should parse Anthropic response', () => {
+    const provider = getProvider('anthropic')!;
+    const result = provider.responseParser({
+      content: [{ type: 'text', text: 'Hello from Claude' }],
+      model: 'claude-sonnet-4-6',
+      usage: { input_tokens: 15, output_tokens: 8 },
+    });
+    expect(result.content).toBe('Hello from Claude');
+    expect(result.model).toBe('claude-sonnet-4-6');
+    expect(result.usage).toEqual({ inputTokens: 15, outputTokens: 8 });
+  });
+
+  it('should parse Google Gemini response', () => {
+    const provider = getProvider('google')!;
+    const result = provider.responseParser({
+      candidates: [{ content: { parts: [{ text: 'Hello from Gemini' }] } }],
+      modelVersion: 'gemini-2.0-flash',
+      usageMetadata: { promptTokenCount: 20, candidatesTokenCount: 10 },
+    });
+    expect(result.content).toBe('Hello from Gemini');
+    expect(result.model).toBe('gemini-2.0-flash');
+    expect(result.usage).toEqual({ inputTokens: 20, outputTokens: 10 });
+  });
+
+  it('should handle empty/malformed responses gracefully', () => {
+    const provider = getProvider('openai')!;
+    const result = provider.responseParser({});
+    expect(result.content).toBe('');
+    expect(result.model).toBe('');
+    expect(result.usage).toBeUndefined();
+  });
+
+  it('should handle missing usage data', () => {
+    const provider = getProvider('anthropic')!;
+    const result = provider.responseParser({
+      content: [{ text: 'test' }],
+      model: 'claude-haiku-4-5',
+    });
+    expect(result.content).toBe('test');
+    expect(result.usage).toBeUndefined();
+  });
+});
+
+describe('AI Provider Validate Requests', () => {
+  it('should build OpenAI validation request', () => {
+    const provider = getProvider('openai')!;
+    const req = provider.validateRequest('sk-test');
+    expect(req.method).toBe('GET');
+    expect(req.url).toContain('/v1/models');
+    expect(req.headers['Authorization']).toBe('Bearer sk-test');
+  });
+
+  it('should build Anthropic validation request', () => {
+    const provider = getProvider('anthropic')!;
+    const req = provider.validateRequest('sk-ant-test');
+    expect(req.method).toBe('POST');
+    expect(req.url).toContain('/v1/messages');
+    expect(req.headers['x-api-key']).toBe('sk-ant-test');
+  });
+
+  it('should build Google validation request with key in URL', () => {
+    const provider = getProvider('google')!;
+    const req = provider.validateRequest('google-key');
+    expect(req.method).toBe('GET');
+    expect(req.url).toContain('key=google-key');
+  });
+
+  it('should build Groq validation request', () => {
+    const provider = getProvider('groq')!;
+    const req = provider.validateRequest('gsk-test');
+    expect(req.method).toBe('GET');
+    expect(req.url).toContain('/models');
+    expect(req.headers['Authorization']).toBe('Bearer gsk-test');
+  });
+
+  it('should build OpenRouter validation request', () => {
+    const provider = getProvider('openrouter')!;
+    const req = provider.validateRequest('sk-or-test');
+    expect(req.method).toBe('GET');
+    expect(req.url).toContain('/models');
+    expect(req.headers['Authorization']).toBe('Bearer sk-or-test');
+  });
+});

--- a/tests/ai/recommender.test.ts
+++ b/tests/ai/recommender.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { parseRecommenderResponse } from '@/lib/ai/recommender';
+
+describe('parseRecommenderResponse', () => {
+  it('should parse clean JSON array', () => {
+    const result = parseRecommenderResponse(JSON.stringify([
+      { id: 'blog-minimal-dark', score: 95, reason: 'Perfect match' },
+      { id: 'blog-code-dark', score: 80, reason: 'Good for code' },
+    ]));
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('blog-minimal-dark');
+    expect(result[0].score).toBe(95);
+    expect(result[0].reason).toBe('Perfect match');
+  });
+
+  it('should parse markdown-wrapped JSON', () => {
+    const result = parseRecommenderResponse('```json\n[{"id":"test","score":90,"reason":"match"}]\n```');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('test');
+  });
+
+  it('should extract array from surrounding text', () => {
+    const result = parseRecommenderResponse('Here are the results:\n[{"id":"test","score":85,"reason":"good"}]\nHope this helps!');
+    expect(result).toHaveLength(1);
+  });
+
+  it('should limit to 5 results', () => {
+    const items = Array.from({ length: 10 }, (_, i) => ({ id: `t${i}`, score: 90 - i, reason: 'match' }));
+    const result = parseRecommenderResponse(JSON.stringify(items));
+    expect(result).toHaveLength(5);
+  });
+
+  it('should handle missing score', () => {
+    const result = parseRecommenderResponse('[{"id":"test","reason":"good"}]');
+    expect(result[0].score).toBe(50); // default
+  });
+
+  it('should handle missing reason', () => {
+    const result = parseRecommenderResponse('[{"id":"test","score":90}]');
+    expect(result[0].reason).toBe('');
+  });
+
+  it('should filter out items without id', () => {
+    const result = parseRecommenderResponse('[{"score":90,"reason":"no id"},{"id":"valid","score":80}]');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('valid');
+  });
+
+  it('should return empty array for invalid input', () => {
+    expect(parseRecommenderResponse('not json')).toEqual([]);
+  });
+
+  it('should return empty array for empty string', () => {
+    expect(parseRecommenderResponse('')).toEqual([]);
+  });
+});

--- a/tests/ai/storage.test.ts
+++ b/tests/ai/storage.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  getApiKey,
+  setApiKey,
+  removeApiKey,
+  clearAllApiKeys,
+  getSelectedProvider,
+  setSelectedProvider,
+  getSelectedModel,
+  setSelectedModel,
+  hasAnyKeyConfigured,
+} from '@/lib/ai/storage';
+
+// Mock localStorage for Node environment
+const store: Record<string, string> = {};
+const localStorageMock = {
+  getItem: vi.fn((key: string) => store[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+  removeItem: vi.fn((key: string) => { delete store[key]; }),
+  key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+  get length() { return Object.keys(store).length; },
+  clear: vi.fn(() => { for (const key of Object.keys(store)) delete store[key]; }),
+};
+
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true });
+
+beforeEach(() => {
+  localStorageMock.clear();
+  vi.clearAllMocks();
+});
+
+describe('API Key Storage', () => {
+  it('should set and get an API key', () => {
+    setApiKey('openai', 'sk-test-123');
+    expect(getApiKey('openai')).toBe('sk-test-123');
+  });
+
+  it('should return null for unset key', () => {
+    expect(getApiKey('openai')).toBeNull();
+  });
+
+  it('should store keys independently per provider', () => {
+    setApiKey('openai', 'sk-openai');
+    setApiKey('anthropic', 'sk-ant-anthropic');
+    setApiKey('google', 'google-key');
+    expect(getApiKey('openai')).toBe('sk-openai');
+    expect(getApiKey('anthropic')).toBe('sk-ant-anthropic');
+    expect(getApiKey('google')).toBe('google-key');
+  });
+
+  it('should remove only the specified provider key', () => {
+    setApiKey('openai', 'sk-openai');
+    setApiKey('anthropic', 'sk-ant-key');
+    removeApiKey('openai');
+    expect(getApiKey('openai')).toBeNull();
+    expect(getApiKey('anthropic')).toBe('sk-ant-key');
+  });
+
+  it('should overwrite existing key', () => {
+    setApiKey('openai', 'sk-old');
+    setApiKey('openai', 'sk-new');
+    expect(getApiKey('openai')).toBe('sk-new');
+  });
+});
+
+describe('clearAllApiKeys', () => {
+  it('should remove all AI-related entries', () => {
+    setApiKey('openai', 'sk-1');
+    setApiKey('anthropic', 'sk-2');
+    setSelectedProvider('openai');
+    setSelectedModel('openai', 'gpt-4o');
+    clearAllApiKeys();
+    expect(getApiKey('openai')).toBeNull();
+    expect(getApiKey('anthropic')).toBeNull();
+    expect(getSelectedProvider()).toBeNull();
+    expect(getSelectedModel('openai')).toBeNull();
+  });
+
+  it('should not remove non-AI localStorage entries', () => {
+    store['other-key'] = 'should-stay';
+    setApiKey('openai', 'sk-1');
+    clearAllApiKeys();
+    expect(store['other-key']).toBe('should-stay');
+  });
+});
+
+describe('Provider Selection', () => {
+  it('should set and get selected provider', () => {
+    setSelectedProvider('anthropic');
+    expect(getSelectedProvider()).toBe('anthropic');
+  });
+
+  it('should return null when no provider selected', () => {
+    expect(getSelectedProvider()).toBeNull();
+  });
+
+  it('should overwrite selected provider', () => {
+    setSelectedProvider('openai');
+    setSelectedProvider('google');
+    expect(getSelectedProvider()).toBe('google');
+  });
+});
+
+describe('Model Selection', () => {
+  it('should set and get model per provider', () => {
+    setSelectedModel('openai', 'gpt-4o');
+    setSelectedModel('anthropic', 'claude-sonnet-4-6');
+    expect(getSelectedModel('openai')).toBe('gpt-4o');
+    expect(getSelectedModel('anthropic')).toBe('claude-sonnet-4-6');
+  });
+
+  it('should return null for unset model', () => {
+    expect(getSelectedModel('openai')).toBeNull();
+  });
+
+  it('should remember model when switching providers', () => {
+    setSelectedModel('openai', 'gpt-4o');
+    setSelectedModel('anthropic', 'claude-haiku-4-5');
+    setSelectedProvider('anthropic');
+    // OpenAI model should still be remembered
+    expect(getSelectedModel('openai')).toBe('gpt-4o');
+    expect(getSelectedModel('anthropic')).toBe('claude-haiku-4-5');
+  });
+});
+
+describe('hasAnyKeyConfigured', () => {
+  it('should return false when no keys are set', () => {
+    expect(hasAnyKeyConfigured()).toBe(false);
+  });
+
+  it('should return true when at least one key is set', () => {
+    setApiKey('groq', 'gsk-test');
+    expect(hasAnyKeyConfigured()).toBe(true);
+  });
+
+  it('should return false after clearing all keys', () => {
+    setApiKey('openai', 'sk-test');
+    clearAllApiKeys();
+    expect(hasAnyKeyConfigured()).toBe(false);
+  });
+
+  it('should return true with multiple keys set', () => {
+    setApiKey('openai', 'sk-1');
+    setApiKey('anthropic', 'sk-2');
+    expect(hasAnyKeyConfigured()).toBe(true);
+  });
+});
+
+describe('Error Handling', () => {
+  it('should handle localStorage errors gracefully for getApiKey', () => {
+    const originalGetItem = localStorageMock.getItem;
+    localStorageMock.getItem = vi.fn(() => { throw new Error('quota exceeded'); });
+    expect(getApiKey('openai')).toBeNull();
+    localStorageMock.getItem = originalGetItem;
+  });
+
+  it('should handle localStorage errors gracefully for setApiKey', () => {
+    const originalSetItem = localStorageMock.setItem;
+    localStorageMock.setItem = vi.fn(() => { throw new Error('quota exceeded'); });
+    // Should not throw
+    expect(() => setApiKey('openai', 'sk-test')).not.toThrow();
+    localStorageMock.setItem = originalSetItem;
+  });
+
+  it('should handle localStorage errors gracefully for hasAnyKeyConfigured', () => {
+    Object.defineProperty(localStorageMock, 'length', {
+      get: () => { throw new Error('access denied'); },
+      configurable: true,
+    });
+    expect(hasAnyKeyConfigured()).toBe(false);
+    // Restore
+    Object.defineProperty(localStorageMock, 'length', {
+      get: () => Object.keys(store).length,
+      configurable: true,
+    });
+  });
+});

--- a/tests/ai/validation.test.ts
+++ b/tests/ai/validation.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { aiValidateSchema, aiGenerateSchema } from '@/lib/ai/validation';
+
+describe('AI Validate Schema', () => {
+  it('should accept valid input', () => {
+    const result = aiValidateSchema.safeParse({
+      provider: 'openai',
+      apiKey: 'sk-test-123',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject missing provider', () => {
+    const result = aiValidateSchema.safeParse({
+      apiKey: 'sk-test-123',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject missing apiKey', () => {
+    const result = aiValidateSchema.safeParse({
+      provider: 'openai',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty apiKey', () => {
+    const result = aiValidateSchema.safeParse({
+      provider: 'openai',
+      apiKey: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject unknown provider', () => {
+    const result = aiValidateSchema.safeParse({
+      provider: 'unknown',
+      apiKey: 'sk-test',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept all valid providers', () => {
+    for (const provider of ['openai', 'anthropic', 'google', 'groq', 'openrouter']) {
+      const result = aiValidateSchema.safeParse({ provider, apiKey: 'test-key' });
+      expect(result.success).toBe(true);
+    }
+  });
+});
+
+describe('AI Generate Schema', () => {
+  const validInput = {
+    provider: 'openai',
+    apiKey: 'sk-test-123',
+    model: 'gpt-4o-mini',
+    prompt: 'Generate a title for a blog post about REST APIs',
+  };
+
+  it('should accept valid input', () => {
+    const result = aiGenerateSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept input with all optional fields', () => {
+    const result = aiGenerateSchema.safeParse({
+      ...validInput,
+      systemPrompt: 'You are a copywriter',
+      maxTokens: 200,
+      temperature: 0.7,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject missing provider', () => {
+    const { provider, ...rest } = validInput;
+    expect(aiGenerateSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it('should reject missing apiKey', () => {
+    const { apiKey, ...rest } = validInput;
+    expect(aiGenerateSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it('should reject missing model', () => {
+    const { model, ...rest } = validInput;
+    expect(aiGenerateSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it('should reject missing prompt', () => {
+    const { prompt, ...rest } = validInput;
+    expect(aiGenerateSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it('should reject empty prompt', () => {
+    expect(aiGenerateSchema.safeParse({ ...validInput, prompt: '' }).success).toBe(false);
+  });
+
+  it('should reject prompt exceeding 10000 chars', () => {
+    const longPrompt = 'a'.repeat(10001);
+    expect(aiGenerateSchema.safeParse({ ...validInput, prompt: longPrompt }).success).toBe(false);
+  });
+
+  it('should reject maxTokens exceeding 4096', () => {
+    expect(aiGenerateSchema.safeParse({ ...validInput, maxTokens: 5000 }).success).toBe(false);
+  });
+
+  it('should reject negative maxTokens', () => {
+    expect(aiGenerateSchema.safeParse({ ...validInput, maxTokens: -1 }).success).toBe(false);
+  });
+
+  it('should reject temperature above 2', () => {
+    expect(aiGenerateSchema.safeParse({ ...validInput, temperature: 2.5 }).success).toBe(false);
+  });
+
+  it('should reject negative temperature', () => {
+    expect(aiGenerateSchema.safeParse({ ...validInput, temperature: -0.1 }).success).toBe(false);
+  });
+
+  it('should accept temperature at boundaries', () => {
+    expect(aiGenerateSchema.safeParse({ ...validInput, temperature: 0 }).success).toBe(true);
+    expect(aiGenerateSchema.safeParse({ ...validInput, temperature: 2 }).success).toBe(true);
+  });
+
+  it('should reject systemPrompt exceeding 5000 chars', () => {
+    const longSystem = 'a'.repeat(5001);
+    expect(aiGenerateSchema.safeParse({ ...validInput, systemPrompt: longSystem }).success).toBe(false);
+  });
+});

--- a/tests/api/ai-generate.test.ts
+++ b/tests/api/ai-generate.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { aiGenerateSchema } from '@/lib/ai/validation';
+
+describe('AI Generate API Schema', () => {
+  const valid = {
+    provider: 'openai',
+    apiKey: 'sk-test',
+    model: 'gpt-4o-mini',
+    prompt: 'Generate titles',
+  };
+
+  it('should accept valid generate request', () => {
+    expect(aiGenerateSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('should accept with all optional fields', () => {
+    expect(aiGenerateSchema.safeParse({
+      ...valid,
+      systemPrompt: 'You are a helper',
+      maxTokens: 200,
+      temperature: 0.7,
+    }).success).toBe(true);
+  });
+
+  it('should reject missing required fields', () => {
+    const { provider, ...noProvider } = valid;
+    const { apiKey, ...noKey } = valid;
+    const { model, ...noModel } = valid;
+    const { prompt, ...noPrompt } = valid;
+    expect(aiGenerateSchema.safeParse(noProvider).success).toBe(false);
+    expect(aiGenerateSchema.safeParse(noKey).success).toBe(false);
+    expect(aiGenerateSchema.safeParse(noModel).success).toBe(false);
+    expect(aiGenerateSchema.safeParse(noPrompt).success).toBe(false);
+  });
+
+  it('should reject out-of-range values', () => {
+    expect(aiGenerateSchema.safeParse({ ...valid, maxTokens: 5000 }).success).toBe(false);
+    expect(aiGenerateSchema.safeParse({ ...valid, temperature: 3 }).success).toBe(false);
+    expect(aiGenerateSchema.safeParse({ ...valid, prompt: 'a'.repeat(10001) }).success).toBe(false);
+  });
+});

--- a/tests/api/ai-validate.test.ts
+++ b/tests/api/ai-validate.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { aiValidateSchema } from '@/lib/ai/validation';
+
+describe('AI Validate API Schema', () => {
+  it('should accept valid validate request', () => {
+    expect(aiValidateSchema.safeParse({ provider: 'openai', apiKey: 'sk-test' }).success).toBe(true);
+    expect(aiValidateSchema.safeParse({ provider: 'anthropic', apiKey: 'sk-ant-test' }).success).toBe(true);
+    expect(aiValidateSchema.safeParse({ provider: 'google', apiKey: 'key' }).success).toBe(true);
+    expect(aiValidateSchema.safeParse({ provider: 'groq', apiKey: 'gsk-test' }).success).toBe(true);
+    expect(aiValidateSchema.safeParse({ provider: 'openrouter', apiKey: 'sk-or-test' }).success).toBe(true);
+  });
+
+  it('should reject missing fields', () => {
+    expect(aiValidateSchema.safeParse({}).success).toBe(false);
+    expect(aiValidateSchema.safeParse({ provider: 'openai' }).success).toBe(false);
+    expect(aiValidateSchema.safeParse({ apiKey: 'test' }).success).toBe(false);
+  });
+
+  it('should reject invalid provider', () => {
+    expect(aiValidateSchema.safeParse({ provider: 'invalid', apiKey: 'test' }).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Fix bug where URL query params for template-specific fields (e.g. `tagline`, `cta`, `planName`) were silently dropped if the template had a default value for the same key
- URL params now always take precedence over template defaults

## Context

When using the API like `?template=saas-startup-bold&tagline=My+Custom+Tagline`, the custom tagline was being ignored because the merge logic checked `!(key in mergedParams)` — but `mergedParams` already contained the template default. Changed to check against `params` (the validated schema output) instead.

## Test plan

- [x] All 145 tests pass
- [x] Verify `og.codercops.com/api/og?template=saas-startup-bold&title=Test&tagline=Custom+Tagline` renders "CUSTOM TAGLINE" instead of "SHIP IT TODAY"